### PR TITLE
Remove ability to send private messages

### DIFF
--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -89,7 +89,7 @@ class MessageCreateForm(ModelForm):
 
     class Meta:
         model = Message
-        exclude = ("writeitinstance", "status", "slug", "moderated", "confirmated")
+        exclude = ("writeitinstance", "status", "slug", "moderated", "confirmated", "public")
 
 
 class MessageSearchForm(SearchForm):

--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -67,15 +67,6 @@ $(".chosen-person-select").chosen();
                         <textarea cols="40" id="id_content" name="content" value="{% if form.content.value %}{{ form.content.value }}{% endif %}" placeholder="{% trans 'Tell me please about the new thing ...' %}" class="form-control" rows="10"></textarea/>
                 </div>
                 <div class="form-group">
-                  <div class="checkbox">
-                      {{ form.public.errors }}
-                      <label>
-                          <input id="id_public" {% if form.public.value %}checked="checked"{% endif %} name="public" type="checkbox" />
-                          {% trans "Is this message public?" %}
-                      </label>
-                  </div>
-                </div>
-                <div class="form-group">
                   <input type='submit' class='btn btn-primary' value= "{% trans 'Submit Message' %}"/>
                 </div>
             </div>

--- a/nuntium/tests/message_form_test.py
+++ b/nuntium/tests/message_form_test.py
@@ -86,7 +86,6 @@ class MessageFormTestCase(TestCase):
         self.assertTrue("author_name" in form.fields)
         self.assertTrue("author_email" in form.fields)
         self.assertTrue("slug" not in form.fields)
-        self.assertTrue("public"  in form.fields)
         self.assertNotIn('moderated', form.fields)
         self.assertNotIn('confirmated', form.fields)
 

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -387,24 +387,6 @@ class InstanceDetailView(TestCase):
         self.assertRedirects(response, url)
 
 
-    def test_flash_message_after_the_creation_of_a_private_message(self):
-        data = {
-            'subject':u'Fiera no está',
-            'content':u'¿Dónde está Fiera Feroz? en la playa?',
-            'author_name':u"Felipe",
-            'public': False,
-            'author_email':u"falvarez@votainteligente.cl",
-            'persons': [self.person1.id]
-        }
-
-        url = self.writeitinstance1.get_absolute_url()
-        response = self.client.post(self.url, data, follow=True)
-
-        expected_acknoledgments = _("Thanks for submitting your message, please check your email and click on the confirmation link, after that your message will be waiting form moderation")
-
-
-        self.assertContains(response, expected_acknoledgments)
-
     def test_if_the_instance_needs_moderation_in_all_messages(self):
         self.writeitinstance1.moderation_needed_in_all_messages = True
         self.writeitinstance1.save()


### PR DESCRIPTION
As part of #436, for now simply remove the public/private tickbox on the new message form.