### PR TITLE
Stop pretending you can edit your profile

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-profile.html
+++ b/nuntium/templates/nuntium/profiles/your-profile.html
@@ -60,7 +60,7 @@
       </div>
       <div class="form-group">
         <div class="col-sm-10 col-sm-offset-2">
-          <button type="submit" class="btn btn-primary">Save profile</button>
+          <button type="submit" class="btn btn-primary hidden">Save profile</button>
         </div>
       </div>
       {% csrf_token %}


### PR DESCRIPTION
The ‘Save Profile’ button doesn’t do anything, so until it does, let’s
just hide it.