### PR TITLE
Fix intermittent test failure.

### DIFF
--- a/mailit/tests/save_raw_email_tests.py
+++ b/mailit/tests/save_raw_email_tests.py
@@ -119,7 +119,9 @@ class IncomingEmailAutomaticallySavesRawMessage(TestCase, IncomingRawEmailMixin)
     # @skip('gotta check API first, because it is not returning the answer')
 
     def mock_request_to_api(self):
-        person = self.outbound_message.message.people[0]
+        person = self.outbound_message.message.people.get(
+            membership__writeitinstance=self.outbound_message.message.writeitinstance,
+            )
 
         answer = Answer.objects.create(
             message=self.outbound_message.message,


### PR DESCRIPTION
There's an intermittent test failure of
test_it_relates_to_an_answer_using_web_answer_creation
with the postgres backend.

The problem is in the mocking up of the API call - you can't just
pick item 0 from the list of people related to a message
and expect it to always be the same person - you need to find
the right person, which in this case is the person who's
a member of the WriteItInstance (I think - I'm finding it a
bit hard to get my head round the concept of how all these
models relate to each other).

There are several other intermittent failures. When looking for
a solution to them I think it would be worth looking out for
[0] on a queryset. Unless the queryset is ordered, this gives
back an arbitrary item. Probably many occurrences of this really
need replacing with calls to .get()