### PR TITLE
Fix typo

### DIFF
--- a/nuntium/templates/nuntium/writeitinstance_advanced_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_advanced_update_form.html
@@ -30,7 +30,7 @@ $(".chosen-person-select").chosen();
 <div class="tab-content">
   <div class="tab-pane active" id="advanced-update">
     <div class="page-header">
-        <h2>{% blocktrans with writeitinstance=writeitinstance %}Editing the advaced parts of {{ writeitinstance }}{% endblocktrans %}</h2>
+        <h2>{% blocktrans with writeitinstance=writeitinstance %}Editing the advanced parts of {{ writeitinstance }}{% endblocktrans %}</h2>
     </div>
 
     <form role="form" action="" method="post">


### PR DESCRIPTION
Replace 'advaced' with 'advanced'.

<!---
@huboard:{"order":427.0,"milestone_order":522,"custom_state":""}
-->
