### PR TITLE
Use standard pluralization rather than custom.

### DIFF
--- a/nuntium/templates/nuntium/message/message_in_list.html
+++ b/nuntium/templates/nuntium/message/message_in_list.html
@@ -6,25 +6,19 @@
 <div class="panel panel-default">
 	<div class="panel-heading">
 	<h4>{{ message.subject }} <a href="{{ message.get_absolute_url }}"><span class="glyphicon glyphicon-link"></span></a></h4>
-	
-	{% if message.answers.all.count > 1 %}
-		{% blocktrans with answers_count=message.answers.all.count %}
-		There are {{ answers_count }} answers
-		{% endblocktrans %}
-	{% endif %}
-	{% if message.answers.all.count < 1 %}
-		{% blocktrans with answers_count=message.answers.all.count %}
-		There are no answers yet
-		{% endblocktrans %}
-	{% endif %}
-	{% if message.answers.all.count == 1 %}
-		{% blocktrans with answers_count=message.answers.all.count %}
-		There is {{ answers_count }} answer
-		{% endblocktrans %}
-	{% endif %}
 
-	
-	
+        {% with answer_count=message.answers.all.count %}
+          {% if not answer_count %}
+            {% trans "There are no answers yet" %}
+          {% else %}
+            {% blocktrans count answer_count=answer_count %}
+              There is {{ answer_count }} answer
+            {% plural %}
+              There are {{ answer_count }} answers
+            {% endblocktrans %}
+          {% endif %}
+        {% endwith %}
+
 	</div>
 	<div class="panel-body">
 	<p>{% markdown %}{{ message.content }}{% endmarkdown %}</p>


### PR DESCRIPTION
Replace some custom pluralization code with a call to
blocktrans with a plural section. This will allow translators
in languages with a dual/other plural forms to translate
properly.

<!---
@huboard:{"order":427.5,"milestone_order":529,"custom_state":""}
-->
