### PR TITLE
Reorder instance edit top menu

### DIFF
--- a/nuntium/templates/nuntium/profiles/per_instance_top_menu.html
+++ b/nuntium/templates/nuntium/profiles/per_instance_top_menu.html
@@ -4,8 +4,8 @@
 <ul class="nav nav-tabs">
   <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' pk=writeitinstance.pk %}">{% trans "Basic Update" %}</a></li>
   <li class="{% if section == 'writeitinstance_advanced_update' %}active{% endif %}"><a href="{% url 'writeitinstance_advanced_update' pk=writeitinstance.config.pk %}">{% trans "Advanced Update" %}</a></li>
-  <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' pk=writeitinstance.pk %}">{% trans "Contacts in this Instance" %}</a></li>
   <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' pk=writeitinstance.pk %}">{% trans "Templates" %}</a></li>
+  <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' pk=writeitinstance.pk %}">{% trans "Contacts" %}</a></li>
   <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' pk=writeitinstance.pk %}">{% trans "Messages" %}</a></li>
   <li class="{% if section == 'relate-writeit-popit' %}active{% endif %}"><a href="{% url 'relate-writeit-popit' pk=writeitinstance.pk %}">{% trans "Popit instances" %}</a></li>
 </ul>
@@ -21,7 +21,7 @@
 {% endfor %}
 {% if writeitinstance.config.testing_mode %}
   <div class="alert alert-info" role="alert">
-      
+
       <a href="{% url 'writeitinstance_advanced_update' pk=writeitinstance.config.pk %}">{% blocktrans %}
       <i class="fa fa-info-circle"></i> This instance is in testing mode which means that all mails will go to you.
       {% endblocktrans %}</a>


### PR DESCRIPTION
Swap 'Contacts' and 'Templates' so that all of the things to edit
are to the left. Also shorten the name of the 'Contacts' tab.

<!---
@huboard:{"order":214.0,"milestone_order":535,"custom_state":""}
-->
