### PR TITLE
Issues/404 api docs on own page

### DIFF
--- a/nuntium/templates/nuntium/profiles/per_instance_top_menu.html
+++ b/nuntium/templates/nuntium/profiles/per_instance_top_menu.html
@@ -8,6 +8,7 @@
   <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' pk=writeitinstance.pk %}">{% trans "Templates" %}</a></li>
   <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' pk=writeitinstance.pk %}">{% trans "Messages" %}</a></li>
   <li class="{% if section == 'relate-writeit-popit' %}active{% endif %}"><a href="{% url 'relate-writeit-popit' pk=writeitinstance.pk %}">{% trans "Popit instances" %}</a></li>
+  <li class="{% if section == 'writeitinstance_api_docs' %}active{% endif %}"><a href="{% url 'writeitinstance_api_docs' pk=writeitinstance.pk %}">{% trans "API" %}</a></li>
 </ul>
 
 {% for rec in writeitinstance.writeitinstancepopitinstancerecord_set.all %}
@@ -21,7 +22,7 @@
 {% endfor %}
 {% if writeitinstance.config.testing_mode %}
   <div class="alert alert-info" role="alert">
-      
+
       <a href="{% url 'writeitinstance_advanced_update' pk=writeitinstance.config.pk %}">{% blocktrans %}
       <i class="fa fa-info-circle"></i> This instance is in testing mode which means that all mails will go to you.
       {% endblocktrans %}</a>

--- a/nuntium/templates/nuntium/writeitinstance_api_docs.html
+++ b/nuntium/templates/nuntium/writeitinstance_api_docs.html
@@ -1,0 +1,44 @@
+{% extends "base_edit.html" %}
+{% load i18n %}
+
+{% block header %}
+  <ul class="breadcrumb">
+    <li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
+    <li><a href="{% url 'account' %}">{% trans "Your profile" %}</a></li>
+    <li><a href="{% url 'your-instances' %}">{% trans "Your instances" %}</a></li>
+    <li class="active">{{ writeitinstance }}</li>
+  </ul>
+
+  {% include 'nuntium/profiles/per_instance_top_menu.html' with section='writeitinstance_api_docs' %}
+{% endblock header %}
+
+{% block content %}
+  <div class="tab-content profile-page-tab-content">
+    <div class="tab-pane active row" id="instances">
+      <div class="tab-content">
+        <div class="tab-pane active" id="basic-update">
+          <div class="page-header">
+            <h2>{% trans "Creating a message using the API" %}</h2>
+            <p>{% trans "To create a message using the API, send a POST request to" %}<br>
+            <code>{{ api_base_url }}message/?format=json&username={{ user.username }}&api_key={{ user.api_key.key }}</code><br>
+            {% trans "with payload data like" %}<br>
+            <code>
+              {<br>
+              &nbsp;&nbsp;&nbsp;&nbsp;'content': '{% trans "Message content here" %}', <br>
+              &nbsp;&nbsp;&nbsp;&nbsp;'writeitinstance': '/api/v1/instance/{{ writeitinstance.id }}/', <br>
+              &nbsp;&nbsp;&nbsp;&nbsp;'persons': [<br>
+              {% for person in writeitinstance.persons.all %}
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'{{ person.popit_url }}'{% if not forloop.last %},{% endif %}</code> ## For {{ person }}<br><code>
+              {% endfor %}
+              &nbsp;&nbsp;&nbsp;&nbsp;], <br>
+              &nbsp;&nbsp;&nbsp;&nbsp;'author_name': '{% trans "Name of sender" %}', <br>
+              &nbsp;&nbsp;&nbsp;&nbsp;'subject': '{% trans "Message subject here" %}'<br>
+            }
+            </code>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -59,34 +59,6 @@ $(".chosen-person-select").chosen();
   </div>
 </div>
 
-<div class="tab-content">
-  <div class="tab-pane active" id="basic-update">
-    <div class="page-header">
-      {% if not writeitinstance.persons.all %}
-      <p>{% trans "Apparently you do not have any people related to this instance. You can add some in the form above." %}</p>
-      {% endif %}
-      <h2>{% trans "Creating a message using the API" %}</h2>
-      <p>{% trans "If you want to create a message using the WriteIt Api for this instance you need to POST to the following url:" %}</p>
-      <h3>{% trans "URL" %}</h3>
-      <code>http://writeit.ciudadanointeligente.org/api/v1/message/?format=json&username={{ user.username }}&api_key={{ user.api_key.key }}</code>
-      <h3>{% trans "Example Payload" %}</h3>
-      <code>
-        {<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;'content': '{% trans "The Content of your Message" %}', <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;'writeitinstance': '/api/v1/instance/{{ writeitinstance.id }}/', <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;'persons': [<br />
-        {% for person in writeitinstance.persons.all %}
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'{{person.popit_url}}'{% if not forloop.last %},{% endif%}</code> ## For {{person}}<br /><code>
-        {% endfor %}
-        &nbsp;&nbsp;&nbsp;&nbsp;], <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;'author_name': '{% trans "Your Name" %}', <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;'subject': '{% trans "The subject for your message" %}'<br />
-      }
-      </code>
-    </div>
-  </div>
-</div>
-
 </div>
 </div>
 

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -12,7 +12,7 @@ from mailit.forms import MailitTemplateForm
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
 
 from nuntium.models import WriteItInstance, WriteItInstanceConfig, WriteitInstancePopitInstanceRecord
-from nuntium.user_section.views import WriteItInstanceUpdateView
+from nuntium.user_section.views import WriteItInstanceUpdateView, WriteItInstanceApiDocsView
 from nuntium.user_section.forms import WriteItInstanceBasicForm, \
     WriteItInstanceAdvancedUpdateForm, WriteItInstanceCreateForm, \
     NewAnswerNotificationTemplateForm, ConfirmationTemplateForm
@@ -429,6 +429,21 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
 
         response = fiera_client.get(url)
         self.assertEquals(response.status_code, 404)
+
+
+class WriteItInstanceApiDocsTestCase(UserSectionTestCase):
+    def setUp(self):
+        super(WriteItInstanceApiDocsTestCase, self).setUp()
+        self.factory = RequestFactory()
+        self.writeitinstance = WriteItInstance.objects.get(id=1)
+
+    def test_per_instance_api_docs(self):
+        url = reverse('writeitinstance_api_docs', kwargs={'pk': self.writeitinstance.pk})
+        request = self.factory.get(url)
+        request.user = self.writeitinstance.owner
+
+        response = WriteItInstanceApiDocsView.as_view()(request, pk=self.writeitinstance.pk)
+        self.assertContains(response, 'http://testserver/api/v1/message/?format=json&username=admin&api_key=')
 
 
 class NewAnswerNotificationUpdateViewForm(UserSectionTestCase):

--- a/nuntium/user_section/urls.py
+++ b/nuntium/user_section/urls.py
@@ -8,7 +8,7 @@ from .views import UserAccountView, WriteItInstanceUpdateView, \
     YourPopitApiInstances, WriteItPopitUpdateView, MessagesPerWriteItInstance, \
     MessageDetail, MessageDelete, AnswerCreateView, ModerationView, AnswerUpdateView, \
     WriteitPopitRelatingView, WriteItDeleteView, WriteItInstanceContactDetailView, \
-    WriteItInstanceStatusView
+    WriteItInstanceStatusView, WriteItInstanceApiDocsView
 
 urlpatterns = patterns('',
     url(r'^accounts/profile/?$', UserAccountView.as_view(), name='account'),
@@ -28,6 +28,9 @@ urlpatterns = patterns('',
     url(r'^writeitinstance/(?P<pk>[-\d]+)/contacts/?$',
         WriteItInstanceContactDetailView.as_view(),
         name='contacts-per-writeitinstance'),
+    url(r'^writeitinstance/(?P<pk>[-\d]+)/api_docs/?$',
+        WriteItInstanceApiDocsView.as_view(),
+        name='writeitinstance_api_docs'),
     url(r'^message/(?P<pk>[-\d]+)/answers/?$',
         MessageDetail.as_view(),
         name='message_detail'),

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -31,7 +31,7 @@ class UserAccountView(TemplateView):
         return super(UserAccountView, self).dispatch(*args, **kwargs)
 
 
-class WriteItInstanceDetailMixin(DetailView):
+class WriteItInstanceDetailBaseView(DetailView):
     model = WriteItInstance
 
     @method_decorator(login_required)
@@ -46,7 +46,7 @@ class WriteItInstanceDetailMixin(DetailView):
         return self.object
 
 
-class WriteItInstanceContactDetailView(WriteItInstanceDetailMixin):
+class WriteItInstanceContactDetailView(WriteItInstanceDetailBaseView):
     template_name = 'nuntium/profiles/contacts/contacts-per-writeitinstance.html'
 
     def get_context_data(self, **kwargs):
@@ -55,7 +55,7 @@ class WriteItInstanceContactDetailView(WriteItInstanceDetailMixin):
         return context
 
 
-class WriteItInstanceStatusView(WriteItInstanceDetailMixin):
+class WriteItInstanceStatusView(WriteItInstanceDetailBaseView):
     def render_to_response(self, context, **response_kwargs):
         status = self.object.pulling_from_popit_status
         return HttpResponse(

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -65,6 +65,16 @@ class WriteItInstanceStatusView(WriteItInstanceDetailBaseView):
         )
 
 
+class WriteItInstanceApiDocsView(WriteItInstanceDetailBaseView):
+    template_name = 'nuntium/writeitinstance_api_docs.html'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(WriteItInstanceApiDocsView, self).get_context_data(*args, **kwargs)
+
+        context['api_base_url'] = self.request.build_absolute_uri('/api/v1/')
+        return context
+
+
 class WriteItInstanceTemplateUpdateView(DetailView):
     model = WriteItInstance
     template_name = 'nuntium/profiles/templates.html'


### PR DESCRIPTION
Shift API docs out of the edit instance page and onto a page of their own. Fixes #404.

<!---
@huboard:{"order":267.5,"milestone_order":536,"custom_state":""}
-->
