### PR TITLE
Issues/440 message page should link to recipient

### DIFF
--- a/nuntium/templates/nuntium/message/message_detail.html
+++ b/nuntium/templates/nuntium/message/message_detail.html
@@ -12,7 +12,7 @@
         {% trans 'This message was sent to' %}
         <br />
             {% for person in message.people %}
-            <span class="label label-default">{{ person.name }}</span>
+              <a class="label label-default" title="{% blocktrans with person_name=person.name %}See all messages sent to {{ person_name }}{% endblocktrans %}" href='{% url 'messages_per_person' slug=message.writeitinstance.slug pk=person.id %}'>{{ person.name }}</a>
             {% endfor %}
     </div>
   </div>
@@ -22,7 +22,7 @@
             {% blocktrans with message.author_name as name %}Asked by {{ name }}.{% endblocktrans %}
         </small>
     </span>
-    
+
   </div>
 </div>
 

--- a/nuntium/templates/nuntium/message/message_in_list.html
+++ b/nuntium/templates/nuntium/message/message_in_list.html
@@ -24,21 +24,12 @@
 	<p>{% markdown %}{{ message.content }}{% endmarkdown %}</p>
 	<i class="glyphicon glyphicon-user"></i>
 	{% for person in message.people %}
-		<span class="label label-default person_name" data-container="body" data-toggle="popover" data-content="<a href='{% url 'messages_per_person' slug=message.writeitinstance.slug pk=person.id %}'>{% blocktrans with person_name=person.name %}See all messages sent to {{ person_name }}{% endblocktrans %}</a>">{{ person.name }}</span>
+	  <a class="label label-default" title="{% blocktrans with person_name=person.name %}See all messages sent to {{ person_name }}{% endblocktrans %}" href='{% url 'messages_per_person' slug=message.writeitinstance.slug pk=person.id %}'>{{ person.name }}</a>
 	{% endfor %}
 
 	<br />
 	<span class="author_name"><small>{% blocktrans with message.author_name as name %}Asked by {{ name }}.{% endblocktrans %}</small></span>
 	</div>
-
-	<script type="text/javascript">
-	$('.person_name').popover({
-		'trigger':'hover',
-		'html':true,
-		'placement':'top',
-		'delay': { show: 0, hide: 1000 }
-	})
-	</script>
 
 </div>
 </dl>


### PR DESCRIPTION
Make the recipient names on a message page into links.
Also stop the links to recipients on pages using message_in_list.html from being on hover, as this was quite hard to click as it sometimes disappeared when the mouse was moved towards it.

<!---
@huboard:{"order":321.5,"milestone_order":537,"custom_state":""}
-->
