### PR TITLE
No message creation form if no contacts.

### DIFF
--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -26,7 +26,7 @@ $(".chosen-person-select").chosen();
 
 {% if writeitinstance.config.testing_mode %}
   <div class="alert alert-info" role="alert">
-      
+
       {% blocktrans %}
       <i class="fa fa-info-circle"></i> This instance is in testing mode which means that all mails will go to the owner and not to the person that you are writing to.
       {% endblocktrans %}
@@ -36,8 +36,20 @@ $(".chosen-person-select").chosen();
   </div>
 {% endif %}
 
-{% if writeitinstance.config.allow_messages_using_form %}
-<div class="panel panel-default writing-panel">
+{% if not writeitinstance.config.allow_messages_using_form %}
+  <div class="panel panel-default">
+      <div class="panel-heading">
+          <h2 class="panel-title">{% trans "Sorry, currently you can not create new messages using this web" %}</h2>
+      </div>
+  </div>
+{% elif not writeitinstance.persons.exists %}
+  <div class="panel panel-default">
+      <div class="panel-heading">
+          <h2 class="panel-title">{% trans "Sorry, there is no-one to write to yet. Please check back soon." %}</h2>
+      </div>
+  </div>
+{% else %}
+  <div class="panel panel-default writing-panel">
     <div class="panel-heading">
         <h2 class="panel-title">{% trans "You can now write your question" %}</h2>
     </div>
@@ -86,13 +98,7 @@ $(".chosen-person-select").chosen();
             </div>
         </form>
     </div>
-</div>
-{% else %}
-<div class="panel panel-default">
-    <div class="panel-heading">
-        <h2 class="panel-title">{% trans "Sorry, currently you can not create new messages using this web" %}</h2>
-    </div>
-</div>
+  </div>
 {% endif %}
 {% if writeitinstance.message_set.count == 0 %}
     <h2>{% trans "There are no messages" %}</h2>

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -357,3 +357,18 @@ class InstanceDetailView(TestCase):
         expected_acknoledgments = _("Thanks for submitting your message, please check your email and click on the confirmation link, after that your message will be waiting form moderation")
 
         self.assertContains(response, expected_acknoledgments)
+
+    def test_no_form_on_homepage_of_empty_instance(self):
+        owner = User.objects.create(
+            username='test-instance-owner',
+            password='foo',
+            )
+        instance = WriteItInstance.objects.create(
+            name="Instance Without Contacts",
+            owner=owner,
+            )
+
+        url = instance.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertIn('there is no-one to write to', response.content)


### PR DESCRIPTION
If there are no available contacts, say that there is no-one to
write to rather than displaying a form for creating a message.
Obviously this all needs design tidying up.

Fixes #401.

<!---
@huboard:{"order":323.6875,"milestone_order":552,"custom_state":""}
-->
