### PR TITLE
Handle text html

### DIFF
--- a/mailit/tests/handle_mails_management_command_test.py
+++ b/mailit/tests/handle_mails_management_command_test.py
@@ -122,7 +122,7 @@ class HandleIncomingEmailCommand(TestCase):
 
             the_answers = Answer.objects.filter(message=identifier.outbound_message.message)
             self.assertEquals(the_answers.count(), 1)
-            self.assertEquals(the_answers[0].content, 'prueba4lafieri\n')
+            self.assertEquals(the_answers[0].content, 'prueba4lafieri')
 
     def test_call_command_does_not_include_identifier_in_content(self):
         identifier = OutboundMessageIdentifier.objects.all()[0]

--- a/mailit/tests/incoming_mail_test.py
+++ b/mailit/tests/incoming_mail_test.py
@@ -55,9 +55,16 @@ class AnswerHandlerTestCase(TestCase):
     def test_class_answer(self):
 
         email_answer = EmailAnswer()
-        self.assertIsNone(email_answer.message_id)
+        self.assertTrue(hasattr(email_answer, 'subject'))
+        self.assertTrue(hasattr(email_answer, 'content_text'))
+        self.assertTrue(hasattr(email_answer, 'content_html'))
+        self.assertTrue(hasattr(email_answer, 'outbound_message_identifier'))
+        self.assertTrue(hasattr(email_answer, 'email_from'))
+        self.assertTrue(hasattr(email_answer, 'when'))
+        self.assertTrue(hasattr(email_answer, 'message_id'))
         email_answer.subject = 'prueba4'
         email_answer.content_text = 'prueba4lafieritaespeluda'
+        email_answer.content_html = '<p>prueba4lafieritaespeluda</p>'
         email_answer.outbound_message_identifier = '8974aabsdsfierapulgosa'
         email_answer.email_from = 'falvarez@votainteligente.cl'
         email_answer.when = 'Wed Jun 26 21:05:33 2013'
@@ -70,6 +77,7 @@ class AnswerHandlerTestCase(TestCase):
         self.assertEquals(email_answer.email_from, 'falvarez@votainteligente.cl')
         self.assertEquals(email_answer.when, 'Wed Jun 26 21:05:33 2013')
         self.assertEquals(email_answer.message_id, '<CAA5PczfGfdhf29wgK=8t6j7hm8HYsBy8Qg87iTU2pF42Ez3VcQ@mail.gmail.com>')
+        self.assertEquals(email_answer.content_html, '<p>prueba4lafieritaespeluda</p>')
         self.assertFalse(email_answer.is_bounced)
 
     @skip("not yet I'm going to do something")
@@ -97,8 +105,8 @@ class ReplyHandlerTestCase(ResourceTestCase):
         self.handler = EmailHandler()
 
     def test_get_only_new_content_and_not_original(self):
-        self.answer = self.handler.handle(self.email)
-        self.assertEquals(self.answer.content_text, u"aass áéíóúñ")
+        answer = self.handler.handle(self.email)
+        self.assertEquals(answer.content_text, u"aass áéíóúñ")
 
 
 class DoesNotIncludeTheIdentifierInTheContent(TestCase):
@@ -156,6 +164,11 @@ class IncomingEmailHandlerTestCase(ResourceTestCase):
     def test_gets_the_content(self):
         self.answer = self.handler.handle(self.email)
         self.assertTrue(self.answer.content_text.startswith('prueba4lafieri'))
+
+    def test_get_html_content(self):
+        '''Getting the html content out of a mail'''
+        self.answer = self.handler.handle(self.email)
+        self.assertIn('prueba4lafieri', self.answer.content_html)
 
     def test_gets_the_outbound_message_identifier_to_which_relate_it(self):
         #make a regexp
@@ -416,6 +429,7 @@ class EmailReadingExamplesTestCase(TestCase):
 
         answer = self.handler.handle(email)
         self.assertEquals(answer.content_text, u"si prueba no más")
+        self.assertIn(u"si prueba no más", answer.content_html)
 
     @skip("this fails because it still has some parts from the origina email, probably this is not easy taken away")
     def test_example2_gmail(self):

--- a/nuntium/migrations/0052_auto__add_field_answer_content_html.py
+++ b/nuntium/migrations/0052_auto__add_field_answer_content_html.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Answer.content_html'
+        db.add_column(u'nuntium_answer', 'content_html',
+                      self.gf('django.db.models.fields.TextField')(default=''),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Answer.content_html'
+        db.delete_column(u'nuntium_answer', 'content_html')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 3, 9, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'default': '\'Hello {{ confirmation.message.author_name }}:<br />\\nWe have received a message written by you in {{ confirmation.message.writeitinstance.name }}.<br />\\nThe message was:<br />\\n<strong>Subject: </strong> {{ confirmation.message.subject }} <br/>\\n<strong>Content: </strong> {{ confirmation.message.content|linebreaks }} <br />\\n<strong>To: </strong>\\n<ul>\\n\\t{% for person in confirmation.message.people %}\\n\\t<li>{{ person.name }}</li>\\n\\t{% endfor %}\\n</ul>\\n<br />\\n\\nPlease confirm that you have sent this message by clicking on the next link<br />\\n<br />\\n<a href="{{ confirmation_full_url }}">{{ confirmation_full_url }}</a>.\\n<br />\\n{% if confirmation.message.public %}\\n<br />\\nOnce you have confirmed, you will be able to access your message if you go to the next url<br />\\n<br />\\n<a href="{{ message_full_url }}">{{ message_full_url }}</a>.\\n{% endif %}\\n<br />\\n\\nThanks\\n\\nThe writeit team.\''}),
+            'content_text': ('django.db.models.fields.TextField', [], {'default': "'Hello {{ confirmation.message.author_name }}:\\nWe have received a message written by you in {{ confirmation.message.writeitinstance.name }}.\\nThe message was:\\nSubject:  {{ confirmation.message.subject }} \\nContent:  {{ confirmation.message.content|linebreaks }}\\nTo: {% for person in confirmation.message.people %}\\n{{ person.name }}\\n{% endfor %}\\n\\nPlease confirm that you have sent this message by copiying the next url in your browser.\\n\\n\\n{{ confirmation_full_url }}.\\n{% if confirmation.message.public %}\\n\\nOnce you have confirmed, you will be able to access your message if you go to the next url\\n\\n\\n{{ message_full_url }}.\\n\\n{% endif %}\\n\\nThanks.\\n\\nThe writeit team.'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'default': "'Confirmation email for a message in WriteIt\\n'", 'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 3, 9, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "'%(person)s has answered to your message %(message)s'", 'max_length': '255'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'default': '\'Dear {{user}}: <br/>\\n<br/>\\nWe received an answer from {{person}} to your message "{{message.subject}}" and the answer is:<br/>\\n<br/>\\n{{answer.content}}<br/>\\n<br/>\\nThanks for using Write-It<br/>\\n-- <br/>\\nThe Write-it Team\''}),
+            'template_text': ('django.db.models.fields.TextField', [], {'default': '\'Dear {{user}}:\\n\\nWe received an answer from {{person}} to your message "{{message.subject}}" and the answer is:\\n\\n{{answer.content}}\\n\\nThanks for using Write-It\\n-- \\nThe Write-it Team\''}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'autosync': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['nuntium']

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -435,6 +435,7 @@ pre_save.connect(slugify_message, sender=Message)
 
 class Answer(models.Model):
     content = models.TextField()
+    content_html = models.TextField()
     person = models.ForeignKey(Person)
     message = models.ForeignKey(Message, related_name='answers')
     created = models.DateTimeField(auto_now=True, null=True)
@@ -664,11 +665,14 @@ class OutboundMessageIdentifier(models.Model):
     key = models.CharField(max_length=255)
 
     @classmethod
-    def create_answer(cls, identifier_key, content):
+    def create_answer(cls, identifier_key, content, content_html=""):
         identifier = cls.objects.get(key=identifier_key)
         message = identifier.outbound_message.message
         person = identifier.outbound_message.contact.person
-        the_created_answer = Answer.objects.create(message=message, person=person, content=content)
+        the_created_answer = Answer.objects.create(message=message,
+            person=person,
+            content=content,
+            content_html=content_html)
         return the_created_answer
 
     def save(self, *args, **kwargs):

--- a/nuntium/tests/answers_test.py
+++ b/nuntium/tests/answers_test.py
@@ -13,12 +13,16 @@ class AnswerTestCase(TestCase):
         self.person_not_in_the_instance = Person.objects.all()[1]
 
     def test_create_an_answer(self):
-        answer = Answer.objects.create(message=self.message, person=self.person, content="the answer to that is ...")
+        answer = Answer.objects.create(message=self.message,
+            person=self.person,
+            content=u"the answer to that is ...",
+            content_html=u"<p>the answer to that is ...</p>")
 
         self.assertTrue(answer.id)
         self.assertEquals(answer.message, self.message)
         self.assertEquals(answer.person, self.person)
-        self.assertEquals(answer.content, "the answer to that is ...")
+        self.assertEquals(answer.content, u"the answer to that is ...")
+        self.assertEquals(answer.content_html, u"<p>the answer to that is ...</p>")
         self.assertTrue(answer.created is not None)
 
     def test_answer_has_unicode(self):

--- a/nuntium/tests/outbound_message_test.py
+++ b/nuntium/tests/outbound_message_test.py
@@ -145,6 +145,18 @@ class OutboundMessageIdentifierTestCase(TestCase):
 
         self.assertEquals(returned_answer, the_answer)
 
+    def test_create_an_answer_with_content_html(self):
+        '''OutboundMessageIdentifier.create_answer can receive a content_html field'''
+        identifier = OutboundMessageIdentifier.objects.get(outbound_message=self.outbound_message)
+        answer_content = u"La fiera no tiene pulgas."
+        answer_content_html = u'<p>La fiera no tiene pulgas.</p>'
+
+        returned_answer = OutboundMessageIdentifier.create_answer(identifier.key,
+            answer_content,
+            content_html=answer_content_html)
+
+        self.assertEquals(returned_answer.content_html, answer_content_html)
+
 
 class PluginMentalMessageTestCase(TestCase):
     '''


### PR DESCRIPTION
This together with #565 should close #428.
This PR adds the ability to store html content of an email. Currently it is not being displayed as the html content would include the signature of the sender, which is really hard to get rid of (for now).

<!---
@huboard:{"order":389.1064453125,"milestone_order":575,"custom_state":""}
-->
