### PR TITLE
Adding an admin for Confirmation Template

### DIFF
--- a/nuntium/admin.py
+++ b/nuntium/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from .models import Message, WriteItInstance, OutboundMessage, MessageRecord, \
-    Answer, AnswerWebHook, NewAnswerNotificationTemplate
+    Answer, AnswerWebHook, NewAnswerNotificationTemplate, \
+    ConfirmationTemplate
 
 from popit.models import ApiInstance, Person
 from mailit.models import MailItTemplate
@@ -115,3 +116,8 @@ admin.site.register(Person, PersonAdmin)
 class NewAnswerNotificationTemplateAdmin(admin.ModelAdmin):
     pass
 admin.site.register(NewAnswerNotificationTemplate, NewAnswerNotificationTemplateAdmin)
+
+
+class ConfirmationTemplateAdmin(admin.ModelAdmin):
+    pass
+admin.site.register(ConfirmationTemplate, ConfirmationTemplateAdmin)


### PR DESCRIPTION
This is a very simple PR which adds to the administration part a ModelAdmin for managing the ConfirmationTemplates, that was missing.

<!---
@huboard:{"order":389.884765625,"milestone_order":579,"custom_state":""}
-->
