### PR TITLE
Add a Vagrantfile for running WriteIt in a Vagrant VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ src
 *.egg-info
 
 .vagrant/
-Vagrantfile

--- a/README.md
+++ b/README.md
@@ -5,16 +5,38 @@ You write it, and we deliver it.
 [![Coverage Status](https://coveralls.io/repos/ciudadanointeligente/write-it/badge.png?branch=master)](https://coveralls.io/r/ciudadanointeligente/write-it)
 [![Code Health](https://landscape.io/github/ciudadanointeligente/write-it/master/landscape.png)](https://landscape.io/github/ciudadanointeligente/write-it/master)
 
-Write-it is an application that aims to deliver messages to people whose contacts are to be private or the messages should be public, for example: members of congress. 
+Write-it is an application that aims to deliver messages to people whose contacts are to be private or the messages should be public, for example: members of congress.
 
 Write-it is a layer on top of [popit](http://popit.mysociety.org) from where it takes the people and adds contacts. The way it delivers messages is using plugins for example: mailit. And this approach allows for future ways of delivering for example: twitter, whatsapp, fax or pager.
 
 Future uses are in [congresoabierto](http://www.congresoabierto.cl) to replace the old "preguntales" (You can [check here](http://congresoabierto.cl/comunicaciones), to see how it used to work) feature, it was inspired by [writetothem](http://www.writetothem.com/).
 
 
+Quick Installation (Vagrant)
+============================
 
-Installation
-------------
+Assuming [you have Vagrant installed](http://docs.vagrantup.com/v2/installation/), run the following:
+
+    git clone https://github.com/ciudadanointeligente/write-it.git
+    cd write-it
+    vagrant up
+
+Vagrant will automatically install WriteIt and all of its dependencies. This can take a few minutes.
+
+Once it’s complete, log into the virtual machine with:
+
+    vagrant ssh
+
+Once you’re inside the virtual machine, run the web server with:
+
+    cd /vagrant
+    ./manage.py runserver 0.0.0.0:8000
+
+And visit http://localhost:8000 on your host machine to use WriteIt.
+
+
+Manual Installation (without Vagrant)
+=====================================
 
 System Requirements
 -------------------
@@ -32,8 +54,6 @@ System Requirements
  * Libssl
 
  In ubuntu you can do ```sudo apt-get install libssl-dev```
-
-
 
 Write-it is built using Django. You should install Django and its dependencies inside a virtualenv. We suggest you use [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) to create and manage virtualenvs, so if you don’t already have it, [go install it](http://virtualenvwrapper.readthedocs.org/en/latest/install.html#basic-installation), remembering in particular to add the required lines to your shell startup file.
 
@@ -53,7 +73,7 @@ Set up the database, creating an admin user when prompted:
 
 Troubleshooting database migration
 ----------------------------------
-There's a problem migrating and the problem looks like 
+There's a problem migrating and the problem looks like
 
 	django.db.utils.OperationalError: no such table: tastypie_apikey
 
@@ -67,7 +87,7 @@ Then run the server:
 
 
 Testing and Development
------------------------
+=======================
 
 If you want to test without PopitAPI or Elasticsearch
 -----------------------------------------------------
@@ -112,7 +132,7 @@ With that done you will be able to access '/accounts/login/'.
 
 
 API clients
------------
+===========
 
 Write-it has been used mostly through its REST API for which there are a number of API clients.
 The github repos and the status of the development are listed below:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+$post_up_message = "** Your Vagrant box is ready to use! \o/ **
+Log in (with 'vagrant ssh') and follow the instructions."
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  # Enable NFS access to the disk
+  config.vm.synced_folder "", "/vagrant", nfs: true
+
+  # NFS requires a host-only network
+  config.vm.network :private_network, ip: "10.11.12.13"
+
+  # Forward ports too so that you can access the vm in your local network
+  # through your hosts' IP address
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  # Provisioning
+  config.vm.provision "shell", path: "scripts/provision.sh", privileged: false
+
+  # Show this message after each `vagrant up`
+  config.vm.post_up_message = $post_up_message
+
+  config.ssh.forward_agent = true
+end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+urllib3
 Django==1.6.10
 django-plugins
 South
@@ -27,7 +28,7 @@ python-dateutil
 gunicorn
 dj-database-url==0.2.2
 dj-static==0.0.5
-psycopg2==2.5.1
+#psycopg2==2.5.1
 static==0.4
 wsgiref==0.1.2
 kombu

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Stop script execution as soon as there are any errors
+set -e
+
+pwd
+now=$(date +"%T")
+echo "$now Running provision.sh"
+
+# Use the en_GB.utf8 locale
+sudo update-locale LANG=en_GB.utf8
+
+# Install the packages we need
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git python-dev python-pip libffi-dev libssl-dev
+
+# :TODO: Set up a virtualenv, to protect us
+# from system python packages
+
+# Install the python requirements
+# We specify a long timeout and use-mirrors to avoid
+# errors like "SSLError: The read operation timed out"
+cd /vagrant
+sudo pip install --timeout=120 --use-mirrors -r requirements.txt
+
+# Set up the Django database
+./manage.py syncdb --noinput
+./manage.py migrate
+
+# Set shell login message
+echo "-----------------------------------------------
+Welcome to the WriteIt vagrant machine
+
+Run the web server with:
+  cd /vagrant
+  ./manage.py runserver 0.0.0.0:8000
+
+Then visit http://localhost:8000 to use WriteIt
+-----------------------------------------------
+" | sudo tee /etc/motd.tail > /dev/null


### PR DESCRIPTION
This includes:
* Simple Vagrantfile with NFS shared directory
* Provisioning script with zero-input django migrations
* Removal of PostgreSQL-specific package (psycopg2) in requirements.txt
* Documentation in README.md
* Steps to run webserver also printed out on SSH login

Vagrant file tested on a Mac. Can't see any reason why it wouldn't also work on Linux.

@duncanparkes – is there any other setup that the Vagrant provisioner could do, to get people up and running quicker?

<!---
@huboard:{"order":94.515625,"milestone_order":590,"custom_state":""}
-->
