### PR TITLE
According to celery-haystack#36 this should fix #597

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ pyasn1
 django-pagination
 django-annoying
 celery-haystack==0.8
+django-celery-transactions<0.2.0


### PR DESCRIPTION
This forces django-celery-transactions version to be < 0.2.0 in order to avoid  celery-haystack#36 and #597  