### PR TITLE
Report this message button

### DIFF
--- a/nuntium/migrations/0057_auto__add_report.py
+++ b/nuntium/migrations/0057_auto__add_report.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Report'
+        db.create_table(u'nuntium_report', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('message', self.gf('django.db.models.fields.related.ForeignKey')(related_name='reports', to=orm['nuntium.Message'])),
+            ('reason', self.gf('django.db.models.fields.TextField')(default='')),
+            ('datetime', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+        ))
+        db.send_create_signal(u'nuntium', ['Report'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Report'
+        db.delete_table(u'nuntium_report')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerattachment': {
+            'Meta': {'object_name': 'AnswerAttachment'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 3, 18, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_text': ('django.db.models.fields.TextField', [], {'default': "'Hello {{ confirmation.message.author_name }}:\\nWe have received a message written by you in {{ confirmation.message.writeitinstance.name }}.\\nThe message was:\\nSubject:  {{ confirmation.message.subject }} \\nContent:  {{ confirmation.message.content|linebreaks }}\\nTo: {% for person in confirmation.message.people %}\\n{{ person.name }}\\n{% endfor %}\\n\\nPlease confirm that you have sent this message by copiying the next url in your browser.\\n\\n\\n{{ confirmation_full_url }}.\\n{% if confirmation.message.public %}\\n\\nOnce you have confirmed, you will be able to access your message if you go to the next url\\n\\n\\n{{ message_full_url }}.\\n\\n{% endif %}\\n\\nThanks.\\n\\nThe writeit team.'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'default': "'Confirmation email for a message in WriteIt\\n'", 'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 3, 18, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "'%(person)s has answered to your message %(message)s'", 'max_length': '255'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'template_text': ('django.db.models.fields.TextField', [], {'default': '\'Dear {{user}}:\\n\\nWe received an answer from {{person}} to your message "{{message.subject}}" and the answer is:\\n\\n{{answer.content}}\\n\\nThanks for using Write-It\\n-- \\nThe Write-it Team\''}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.report': {
+            'Meta': {'object_name': 'Report'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reports'", 'to': u"orm['nuntium.Message']"}),
+            'reason': ('django.db.models.fields.TextField', [], {'default': "''"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_create_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'autosync': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['nuntium']

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -932,3 +932,9 @@ class WriteitInstancePopitInstanceRecord(models.Model):
         self.status = status
         self.status_explanation = explanation
         self.save()
+
+
+class Report(models.Model):
+    message = models.ForeignKey(Message, related_name="reports")
+    reason = models.TextField(default="")
+    datetime = models.DateTimeField(auto_now_add=True)

--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 # from django.conf.urls.i18n import i18n_patterns
 
 from .views import WriteItInstanceDetailView, PerInstanceSearchView, \
-    MessagesPerPersonView, MessageDetailView
+    MessagesPerPersonView, MessageDetailView, ReportCreateView
 
 from django_downloadview import ObjectDownloadView
 from nuntium.models import AnswerAttachment
@@ -19,4 +19,5 @@ urlpatterns = patterns('',
     url(r'^(?P<slug>[-\w]+)/search/?$', PerInstanceSearchView(), name='instance_search'),
     url(r'^(?P<slug>[-\w]+)/per_person/(?P<pk>[-\d]+)/?$', MessagesPerPersonView.as_view(), name='messages_per_person'),
     url(r'^/attachment/(?P<pk>[-\d]+)/?$', download_attachment_view, name='attachment'),
+    url(r'^/report-message/(?P<pk>[-\d]+)/?$', ReportCreateView.as_view(), name='create-report'),
 )

--- a/nuntium/templates/nuntium/message/message_detail.html
+++ b/nuntium/templates/nuntium/message/message_detail.html
@@ -24,6 +24,7 @@
       {% endif %}</div>
 
   </div>
+  <!--span><a href="{% url 'create-report' pk=message.pk %}">Do you want to report this message?</a></span-->
 </div>
 
 

--- a/nuntium/templates/nuntium/profiles/message_detail.html
+++ b/nuntium/templates/nuntium/profiles/message_detail.html
@@ -61,11 +61,11 @@
 	</div>
 
 	<div class="col-md-8">
+        <h4>{% trans 'Answers' %}</h4>
 		<table class="table">
 		  <tr>
 		  	<th>{% trans "Person" %}</th>
 		  	<th>{% trans "Content" %}</th>
-		  	<th>{% trans "Actions" %}</th>
 		  </tr>
 		  {% for answer in message.answers.all %}
 			  <tr>
@@ -83,6 +83,23 @@
 		  {% endfor %}
 		</table>
 	</div>
+
+    <div class="col-md-4"></div>
+    <div class="col-md-8">
+        <h4>{% trans 'Reports' %}</h4>
+        <table class="table">
+          <tr>
+            <th>{% trans "Reason" %}</th>
+            <th>{% trans "Date" %}</th>
+          </tr>
+          {% for report in message.reports.all %}
+              <tr>
+                <td>{{report.reason}}</td>
+                <td>{{report.datetime}}</td>
+              </tr>
+          {% endfor %}
+        </table>
+    </div>
 </div>
 </div>
 

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -50,6 +50,10 @@
               {% if message.public and message.confirmated %}
               <a target="_blank" href="{% url 'message_detail' slug=message.slug instance_slug=writeitinstance.slug %}"><i class="fa fa-external-link"></i></a>
               {% endif %}
+              {% if message.reports.all %}
+              <a href="{% url 'message_detail' pk=message.pk %}"><i class="fa fa-exclamation-triangle" data-toggle="tooltip" data-placement="top" title="{% trans 'This message has been reported' %}"></i>
+              <!-- click here to  do something about it--></a>
+              {% endif %}
             </td>
             <td>{{ message.content|truncatechars:50|linebreaksbr }}</td>
             <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% if message.public %}{% trans 'This message can be seen by everyone' %}{% else %}{% trans 'TThis message can be seen by you only' %}{% endif %}"><i class="fa {% if message.public %}fa-eye{% else %}fa-eye-slash{% endif %}"></i></div></td>
@@ -103,6 +107,7 @@ $(function(){
     })
 
   })
+  $('[data-toggle="tooltip"]').tooltip()
 })
 
 </script>

--- a/nuntium/templates/nuntium/reports/report_form.html
+++ b/nuntium/templates/nuntium/reports/report_form.html
@@ -1,0 +1,5 @@
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button>Submit</button>
+</form>

--- a/nuntium/tests/report_message_tests.py
+++ b/nuntium/tests/report_message_tests.py
@@ -1,0 +1,64 @@
+from global_test_case import GlobalTestCase as TestCase
+from nuntium.models import Report, Message
+from django.core.urlresolvers import reverse
+
+
+class ReportThisMessageTestCase(TestCase):
+    def setUp(self):
+        super(ReportThisMessageTestCase, self).setUp()
+        # Message with id2 has been confirmed
+        self.message = Message.objects.get(id=2)
+
+    def test_a_message_can_have_a_report(self):
+        '''A message can have a report which contains a reason'''
+        report = Report.objects.create(
+            message=self.message,
+            reason=u"Because ..."
+            )
+
+        self.assertEquals(report.message, self.message)
+        self.assertEquals(report.reason, "Because ...")
+        self.assertTrue(report.datetime)
+        # can a message have several reports?
+        # why not?
+        report2 = Report.objects.create(
+            message=self.message,
+            reason=u"Another reason by someone else"
+            )
+        self.assertEquals(report2.message, self.message)
+        self.assertIn(report, self.message.reports.all())
+        self.assertIn(report2, self.message.reports.all())
+
+
+class CreateReportView(TestCase):
+    def setUp(self):
+        super(CreateReportView, self).setUp()
+        # Message with id2 has been confirmed
+        self.message = Message.objects.get(id=2)
+
+    def test_get_the_url_for_posting_a_new_report(self):
+        '''Get the URL for a new report brings the form'''
+        url = reverse('create-report', kwargs={'pk': self.message.id})
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        self.assertIn('form', response.context)
+
+    def test_post_a_new_report(self):
+        url = reverse('create-report', kwargs={'pk': self.message.id})
+        data = {
+            'reason': "I think that message_2 is offensive"
+        }
+        response = self.client.post(url, data=data)
+
+        self.assertTrue(self.message.reports.all())
+        self.assertEquals(self.message.reports.count(), 1)
+        the_report = self.message.reports.first()
+        self.assertEquals(the_report.reason, data['reason'])
+        instance_url = reverse('instance_detail', kwargs={'slug': self.message.writeitinstance.slug})
+        self.assertRedirects(response, instance_url)
+
+    def test_404_when_message_does_not_exist(self):
+        '''I get a 404 when a message does not exist'''
+        url = reverse('create-report', kwargs={'pk': 144})
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 404)

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -10,8 +10,9 @@ from haystack.views import SearchView
 from itertools import chain
 from popit.models import Person
 from django.db.models import Q
-from .models import WriteItInstance, Confirmation, Message, Moderation
+from .models import WriteItInstance, Confirmation, Message, Moderation, Report
 from .forms import MessageCreateForm, MessageSearchForm, PerInstanceSearchForm
+from django.shortcuts import get_object_or_404
 
 
 class HomeTemplateView(TemplateView):
@@ -214,3 +215,21 @@ class MessagesPerPersonView(ListView):
         context = super(MessagesPerPersonView, self).get_context_data(**kwargs)
         context['person'] = self.person
         return context
+
+
+class ReportCreateView(CreateView):
+    model = Report
+    template_name = 'nuntium/reports/report_form.html'
+    fields = ['reason', ]
+
+    def get_success_url(self):
+        return reverse('instance_detail', kwargs={'slug': self.message.writeitinstance.slug})
+
+    def dispatch(self, *args, **kwargs):
+
+        self.message = get_object_or_404(Message, id=self.kwargs['pk'])
+        return super(ReportCreateView, self).dispatch(*args, **kwargs)
+
+    def form_valid(self, form):
+        form.instance.message = self.message
+        return super(ReportCreateView, self).form_valid(form)


### PR DESCRIPTION
This PR does:
- Adds a model called Report related to a message with the "reason" and "datetime" attributes, so the owner of the instance knows a bit more about why it was reported.
- Adds a view and a url for creating reports per messages.
- Displays the existance of reports and details about the report in the backend.

This PR does not:
- Allow a user to hide a message if she/he thinks is necessary.
- Display the link for adding a report, as it is hidden.

Questions regarding #200: 
- A user can hide a message for no reason?
- How should we display a report form?

<!---
@huboard:{"order":354.55859375,"milestone_order":603,"custom_state":""}
-->
