### PR TITLE
585 hide a message

### DIFF
--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -49,13 +49,13 @@
               {% endif %}
             </td>
             <td>{{ message.content|truncatechars:50|linebreaksbr }}</td>
-            <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% if message.public %}{% trans 'This message can be seen by everyone' %}{% else %}{% trans 'TThis message can be seen by you only' %}{% endif %}"><i class="fa {% if message.public %}fa-eye{% else %}fa-eye-slash{% endif %}"></i></div></td>
+            <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% if message.public %}{% trans 'This message can be seen by everyone' %}{% else %}{% trans 'TThis message can be seen by you only' %}{% endif %}"><i class="fa {% if message.public %}fa-eye{% else %}fa-eye-slash{% endif %}"></i> <a class="toggle-public" href="{% url 'toggle_public' slug=message.writeitinstance.slug pk=message.pk %}">{% trans "Toggle public"%}</a></div></td>
             <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% if message.confirmated %}{% trans 'The author of this email has confirmed that this was sent from her/his email' %}{% else %}{% trans 'The author of this email has not  confirmed that this was sent from her/his email' %}{% endif %}"><i class="fa {% if message.confirmated %}fa-check-circle-o{% else %}fa-times-circle-o{% endif %}"></i></div></td>
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
               {% if message.moderated %}
               <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been moderated' %}"><i class="fa fa-check-circle-o"></i></div></td>
               {% else %}
-              <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not been moderated and you can moderate it by clicking here' %}"><i class="fa fa-times-circle-o"></i> <a class="moderate" href="{% url 'accept_message' pk=message.pk %}">{% trans "Moderate"%}</a></div></td>
+              <td><div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not been moderated and you can moderate it by clicking here' %}"><i class="fa fa-times-circle-o"></i> <a class="moderate" href="{% url 'accept_message' slug=message.writeitinstance.slug pk=message.pk %}">{% trans "Moderate"%}</a></div></td>
               {% endif %}
 
             {% endif %}
@@ -88,15 +88,16 @@
 </div>
 <script type="text/javascript">
 $('.explanation').tooltip({})
-$(function(){
-  $('.moderate').click(function(event){
-    event.preventDefault();
-    var url = $(event.target).attr('href');
-    $.post(url, function(data){
-      location.reload();
-    })
-
+var postToUrlAndReload = function(event){
+  event.preventDefault();
+  var url = $(event.target).attr('href');
+  $.post(url, function(data){
+    location.reload();
   })
+}
+$(function(){
+  $('.moderate').click(postToUrlAndReload)
+  $('.toggle-public').click(postToUrlAndReload)
 })
 
 </script>

--- a/nuntium/urls.py
+++ b/nuntium/urls.py
@@ -29,6 +29,7 @@ from nuntium.user_section.views import (
     WriteItInstanceTemplateUpdateView,
     WriteItInstanceUpdateView,
     WriteitPopitRelatingView,
+    MessageTogglePublic,
 )
 from nuntium.user_section.stats import StatsView
 
@@ -67,6 +68,7 @@ managepatterns = patterns('',
     url(r'^delete/$',
         WriteItDeleteView.as_view(template_name="nuntium/profiles/writeitinstance_check_delete.html"),
         name='delete_an_instance'),
+    url(r'^messages/(?P<pk>[-\d]+)/toggle-public/$', MessageTogglePublic.as_view(), name='toggle_public'),
 )
 
 write_message_wizard = WriteMessageView.as_view(url_name='write_message_step')

--- a/nuntium/user_section/tests/hide_a_message_tests.py
+++ b/nuntium/user_section/tests/hide_a_message_tests.py
@@ -1,0 +1,59 @@
+from nuntium.user_section.tests.user_section_views_tests import UserSectionTestCase
+from django.core.urlresolvers import reverse
+from nuntium.models import Message
+import json
+from django.contrib.auth.models import User
+
+
+class HideAMessageTestCase(UserSectionTestCase):
+    def setUp(self):
+        super(HideAMessageTestCase, self).setUp()
+        self.message = Message.objects.get(id=2)
+        self.owner = self.message.writeitinstance.owner
+        self.owner.set_password('feroz')
+        self.owner.save()
+
+    def test_post_to_the_url_for_toggle_public(self):
+        '''There is a url for toggling public/hidden a message'''
+
+        self.message.public = True
+        self.message.save()
+
+        url = reverse('toggle_public', kwargs={'slug': self.message.writeitinstance.slug,
+            'pk': self.message.pk})
+
+        self.client.login(username=self.owner.username, password='feroz')
+        response = self.client.post(url)
+        self.assertTrue(response.status_code, 200)
+        the_message_again = Message.objects.get(id=self.message.id)
+        self.assertFalse(the_message_again.public)
+        # Because I'm hoping that this url is an ajax call I should receive
+        # something that tells the UI that the message has turned into private now
+        response_object = json.loads(response.content)
+        # I think it should probably return the id of the
+        # recently changed and the public status
+        self.assertEquals(response_object['pk'], self.message.id)
+        self.assertFalse(response_object['public'])
+        # toggling Hidden
+        response_public = json.loads(self.client.post(url).content)
+        self.assertTrue(response_public['public'])
+
+    def test_non_logged_and_non_owner_toggling_public(self):
+        '''
+        Someone that is not logged in should not be able to toggle public
+        '''
+        self.message.public = True
+        self.message.save()
+
+        url = reverse('toggle_public', kwargs={'slug': self.message.writeitinstance.slug,
+            'pk': self.message.pk})
+
+        response = self.client.post(url)
+        self.assertEquals(response.status_code, 404)
+        self.assertTrue(Message.objects.get(id=self.message.id).public)
+
+        other_user = User.objects.create_user(username="other", password='password')
+        self.client.login(username=other_user.username, password='password')
+        response = self.client.post(url)
+        self.assertTrue(Message.objects.get(id=self.message.id).public)
+        self.assertEquals(response.status_code, 404)

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -15,6 +15,8 @@ from nuntium.user_section.views import WriteItInstanceUpdateView, WriteItInstanc
 from nuntium.user_section.forms import WriteItInstanceBasicForm, \
     WriteItInstanceAdvancedUpdateForm, WriteItInstanceCreateForm, \
     NewAnswerNotificationTemplateForm, ConfirmationTemplateForm
+from nuntium.popit_api_instance import PopitApiInstance
+import json
 
 
 class UserSectionTestCase(TestCase):
@@ -198,9 +200,6 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
         response = c.post(url, data=self.data, follow=True)
 
         self.assertEquals(response.status_code, 404)
-
-from nuntium.popit_api_instance import PopitApiInstance
-import json
 
 
 class WriteItInstancePullingDetailViewTestCase(UserSectionTestCase):

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -377,3 +377,21 @@ class WriteItDeleteView(DeleteView):
     def get_success_url(self):
         url = reverse('your-instances')
         return url
+
+
+class MessageTogglePublic(View):
+    def dispatch(self, *args, **kwargs):
+        if not self.request.user.is_authenticated():
+            raise Http404
+        return super(MessageTogglePublic, self).dispatch(*args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        writeitinstance = get_object_or_404(WriteItInstance, slug=self.kwargs['slug'],
+            owner=self.request.user)
+        message = get_object_or_404(writeitinstance.message_set.all(), pk=self.kwargs['pk'])
+        message.public = not message.public
+        message.save()
+        return HttpResponse(
+            json.dumps({'pk': message.id, 'public': message.public}),
+            content_type="application/json"
+        )


### PR DESCRIPTION
This allows a user to 'hide' a message, in other words it turns the message non-public and fixes a {% url %} in messages_per_instance.html.

<!---
@huboard:{"order":177.216796875,"milestone_order":640,"custom_state":""}
-->
