### PR TITLE
After logout, redirect to '/'.

### DIFF
--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -80,4 +80,5 @@ urlpatterns = i18n_patterns('',
     url(r'^per_person/(?P<pk>[-\d]+)/$', MessagesPerPersonView.as_view(), name='messages_per_person'),
     url(r'^attachment/(?P<pk>[-\d]+)/$', download_attachment_view, name='attachment'),
     url(r'^manage/', include(managepatterns)),
+    url(r'^accounts/logout/$', 'django.contrib.auth.views.logout', kwargs={'next_page': '/'}, name='logout'),
 )

--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -62,7 +62,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="{% url 'django.contrib.auth.views.logout' subdomain=None %}">
+                                <a href="{% url 'django.contrib.auth.views.logout' %}">
                                     <span class="glyphicon glyphicon-log-out"></span>
                                     {% trans "Sign out" %}
                                 </a>

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -60,7 +60,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' subdomain=None %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
                   <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Your WriteIts" %}</a></li>
-                  <li><a href="{% url 'django.contrib.auth.views.logout' subdomain=None %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
+                  <li><a href="{% url 'django.contrib.auth.views.logout' %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
                 </ul>
               </li>
               {% endif %}

--- a/writeit/urls.py
+++ b/writeit/urls.py
@@ -35,6 +35,7 @@ urlpatterns += i18n_patterns('',
 
     url(r'^', include('nuntium.user_section.urls')),
 
+    url(r'^accounts/logout/$', 'django.contrib.auth.views.logout', kwargs={'next_page': '/'}, name='logout'),
     (r'accounts/', include('django.contrib.auth.urls')),
 
 )


### PR DESCRIPTION
I've hard coded this to '/' rather than using reverse because
I can't see an easy way to get the reverse to use the right
subdomain without implementing a wrapper for the logout view
(which we could do in future).

Fixes #633.

<!---
@huboard:{"order":254.7491455078125,"milestone_order":644,"custom_state":""}
-->
