### PR TITLE
Issues/610 resync popit

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -905,6 +905,13 @@ from tastypie.models import create_api_key
 
 models.signals.post_save.connect(create_api_key, sender=User)
 
+PERIODICITY = (
+    ('--', 'Never'),
+    ('2D', 'Twice every Day'),
+    ('1D', 'Daily'),
+    ('1W', 'Weekly'),
+)
+
 
 class WriteitInstancePopitInstanceRecord(models.Model):
     STATUS_CHOICES = (
@@ -917,6 +924,11 @@ class WriteitInstancePopitInstanceRecord(models.Model):
     writeitinstance = models.ForeignKey(WriteItInstance)
     popitapiinstance = models.ForeignKey(ApiInstance)
     autosync = models.BooleanField(default=True)
+    periodicity = models.CharField(
+        max_length="1",
+        choices=PERIODICITY,
+        default='1W',
+        )
     status = models.CharField(
         max_length="20",
         choices=STATUS_CHOICES,

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -923,7 +923,6 @@ class WriteitInstancePopitInstanceRecord(models.Model):
         )
     writeitinstance = models.ForeignKey(WriteItInstance)
     popitapiinstance = models.ForeignKey(ApiInstance)
-    autosync = models.BooleanField(default=True)
     periodicity = models.CharField(
         max_length="1",
         choices=PERIODICITY,

--- a/nuntium/tasks.py
+++ b/nuntium/tasks.py
@@ -21,8 +21,9 @@ def pull_from_popit(writeitinstance, popit_api_instance):
 
 
 @task()
-def update_all_popits():
-    all_records = WriteitInstancePopitInstanceRecord.objects.filter(autosync=True)
+def update_all_popits(periodicity='1W'):
+    all_records = WriteitInstancePopitInstanceRecord.objects.filter(autosync=True,
+        periodicity=periodicity)
     logger.info(u'Complete resync of all instances')
     for record in all_records:
         popit_api_instance = PopitApiInstance.objects.get(id=record.popitapiinstance.id)

--- a/nuntium/tasks.py
+++ b/nuntium/tasks.py
@@ -22,8 +22,7 @@ def pull_from_popit(writeitinstance, popit_api_instance):
 
 @task()
 def update_all_popits(periodicity='1W'):
-    all_records = WriteitInstancePopitInstanceRecord.objects.filter(autosync=True,
-        periodicity=periodicity)
+    all_records = WriteitInstancePopitInstanceRecord.objects.filter(periodicity=periodicity)
     logger.info(u'Complete resync of all instances')
     for record in all_records:
         popit_api_instance = PopitApiInstance.objects.get(id=record.popitapiinstance.id)

--- a/nuntium/tests/popit_writeit_relation_tests.py
+++ b/nuntium/tests/popit_writeit_relation_tests.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from mock import patch, call
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
+from nuntium.user_section.forms import WriteItPopitUpdateForm
 
 
 class PopitWriteitRelationRecord(TestCase):
@@ -223,15 +224,9 @@ class PopitWriteitRelationRecord(TestCase):
         set_status.assert_has_calls(calls)
 
 
-class UpdateStatusOfPopitWriteItRelation(TestCase):
-    '''
-    This test cases should deal with users wanting to:
-    * Manually resync their instances
-    * How often they want their instances to be resynced
-    * Disable syncing of the instance
-    '''
+class WriteItPopitTestCase(TestCase):
     def setUp(self):
-        super(UpdateStatusOfPopitWriteItRelation, self).setUp()
+        super(WriteItPopitTestCase, self).setUp()
         self.writeitinstance = WriteItInstance.objects.get(id=1)
         self.owner = self.writeitinstance.owner
         self.owner.set_password('feroz')
@@ -245,6 +240,17 @@ class UpdateStatusOfPopitWriteItRelation(TestCase):
             writeitinstance=self.writeitinstance,
             popitapiinstance=self.popit_api_instance
             )
+
+
+class UpdateStatusOfPopitWriteItRelation(WriteItPopitTestCase):
+    '''
+    This test cases should deal with users wanting to:
+    * Manually resync their instances
+    * How often they want their instances to be resynced
+    * Disable syncing of the instance
+    '''
+    def setUp(self):
+        super(UpdateStatusOfPopitWriteItRelation, self).setUp()
 
     def test_post_to_the_url_for_manual_resync(self):
         '''Resyncing can be done by posting to a url'''
@@ -285,3 +291,17 @@ class UpdateStatusOfPopitWriteItRelation(TestCase):
         self.client.login(username=other_user.username, password='s3cr3t0')
         response = self.client.post(url)
         self.assertEquals(response.status_code, 404)
+
+
+class UpdateRecordFormTestCase(WriteItPopitTestCase):
+    '''
+    This deals with a Form to update the periodicity of syncronization of an instance
+    '''
+    def setUp(self):
+        super(UpdateRecordFormTestCase, self).setUp()
+
+    def test_validate_the_form(self):
+        data = {'periodicity': '1D'}
+        form = WriteItPopitUpdateForm(data, instance=self.popit_writeit_record)
+        self.assertIn('periodicity', form.fields)
+        self.assertTrue(form.is_valid())

--- a/nuntium/tests/popit_writeit_relation_tests.py
+++ b/nuntium/tests/popit_writeit_relation_tests.py
@@ -40,6 +40,7 @@ class PopitWriteitRelationRecord(TestCase):
         self.assertTrue(record.created)
         self.assertTrue(record.autosync)
         self.assertEquals(record.status, 'nothing')
+        self.assertEquals(record.periodicity, '1W')  # Weekly
         self.assertFalse(record.status_explanation)
 
     def test_unicode(self):

--- a/nuntium/tests/popit_writeit_relation_tests.py
+++ b/nuntium/tests/popit_writeit_relation_tests.py
@@ -38,7 +38,6 @@ class PopitWriteitRelationRecord(TestCase):
         self.assertEquals(record.popitapiinstance, self.api_instance)
         self.assertTrue(record.updated)
         self.assertTrue(record.created)
-        self.assertTrue(record.autosync)
         self.assertEquals(record.status, 'nothing')
         self.assertEquals(record.periodicity, '1W')  # Weekly
         self.assertFalse(record.status_explanation)

--- a/nuntium/tests/tasks_test.py
+++ b/nuntium/tests/tasks_test.py
@@ -116,7 +116,8 @@ class PeriodicallyPullFromPopitClass(TestCase):
             writeitinstance=self.writeitinstance,
             popitapiinstance=self.popit_api_instance
         )
-        writeitinstance_popit_record.autosync = False
+        # Periodicity = 0  means that it is never going to send anything
+        writeitinstance_popit_record.periodicity = 0
         writeitinstance_popit_record.save()
 
         # The record has been set to autosync False

--- a/nuntium/tests/tasks_test.py
+++ b/nuntium/tests/tasks_test.py
@@ -8,7 +8,7 @@ from nuntium.popit_api_instance import PopitApiInstance
 from django.contrib.auth.models import User
 from django.utils.unittest import skipUnless
 from django.conf import settings
-from nuntium.tasks import pull_from_popit
+from nuntium.tasks import pull_from_popit, update_all_popits
 
 
 class TasksTestCase(TestCase):
@@ -80,8 +80,6 @@ class PullFromPopitTask(TestCase):
         pull_from_popit.delay(writeitinstance, self.api_instance1)  # Returns result
         self.assertTrue(writeitinstance.persons.all())
 
-from nuntium.tasks import update_all_popits
-
 
 @skipUnless(settings.LOCAL_POPIT, "No local popit running")
 class PeriodicallyPullFromPopitClass(TestCase):
@@ -106,6 +104,7 @@ class PeriodicallyPullFromPopitClass(TestCase):
         popit_load_data("other_persons")
 
         # This means that if I run the task then it should update the persons
+        # I'm running the weekly job by default
         update_all_popits.delay()
 
         persons_after_updating = list(self.writeitinstance.persons.all())
@@ -127,3 +126,25 @@ class PeriodicallyPullFromPopitClass(TestCase):
         persons_after_updating = list(self.writeitinstance.persons.all())
         # It should not have updated our writeit instance
         self.assertEquals(self.previously_created_persons, persons_after_updating)
+
+    def test_autosyncs_receiving_a_parameter_with_the_periodicity(self):
+        '''It can receive a parameter refering to the periodicity'''
+        writeitinstance_popit_record = WriteitInstancePopitInstanceRecord.objects.get(
+            writeitinstance=self.writeitinstance,
+            popitapiinstance=self.popit_api_instance
+        )
+        writeitinstance_popit_record.periodicity = '1D'  # Daily
+        writeitinstance_popit_record.save()
+        popit_load_data("other_persons")
+        # Now because it is receiving the default value = '1W'
+        # it should not pull anyone
+        update_all_popits.delay()
+
+        persons_after_updating = list(self.writeitinstance.persons.all())
+        self.assertEquals(self.previously_created_persons, persons_after_updating)
+
+        # But If I tell the runner that I'm running the daily
+        # process then it should change it
+        update_all_popits.delay(periodicity="1D")
+        persons_after_updating = list(self.writeitinstance.persons.all())
+        self.assertNotEquals(self.previously_created_persons, persons_after_updating)

--- a/nuntium/urls.py
+++ b/nuntium/urls.py
@@ -24,6 +24,7 @@ from nuntium.user_section.views import (
     WriteItInstanceTemplateUpdateView,
     WriteItInstanceUpdateView,
     WriteitPopitRelatingView,
+    ReSyncFromPopit,
 )
 
 
@@ -46,6 +47,7 @@ managepatterns = patterns('',
     url(r'^settings/$', WriteItInstanceAdvancedUpdateView.as_view(), name='writeitinstance_advanced_update'),
     url(r'^settings/api/$', WriteItInstanceApiDocsView.as_view(), name='writeitinstance_api_docs'),
     url(r'^settings/sources/$', WriteitPopitRelatingView.as_view(), name='relate-writeit-popit'),
+    url(r'^settings/sources/resync/(?P<popit_api_pk>[-\d]+)/$', ReSyncFromPopit.as_view(), name='resync-from-popit'),
     url(r'^settings/templates/$', WriteItInstanceTemplateUpdateView.as_view(), name='writeitinstance_template_update'),
     url(r'^settings/templates/new_answer_notification/$', NewAnswerNotificationTemplateUpdateView.as_view(), name='edit_new_answer_notification_template'),
     url(r'^settings/templates/confirmation_template/$', ConfirmationTemplateUpdateView.as_view(), name='edit_confirmation_template'),

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -5,7 +5,8 @@ from django.core import validators
 
 from nuntium.models import WriteItInstance, \
     NewAnswerNotificationTemplate, \
-    ConfirmationTemplate, Answer, WriteItInstanceConfig
+    ConfirmationTemplate, Answer, WriteItInstanceConfig, \
+    WriteitInstancePopitInstanceRecord
 
 from django.forms import ValidationError, ModelChoiceField, Form, URLField
 
@@ -157,3 +158,9 @@ class RelatePopitInstanceWithWriteItInstance(Form):
             self.cleaned_data['popit_url']
             )
         return result
+
+
+class WriteItPopitUpdateForm(ModelForm):
+    class Meta:
+        model = WriteitInstancePopitInstanceRecord
+        fields = ['periodicity', ]

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -277,14 +277,34 @@ from celery.schedules import crontab
 djcelery.setup_loader()
 
 CELERYBEAT_SCHEDULE = {
-    # Executes every Monday morning at 7:30 A.M
+    # Sends emails every 2 minutes
     'send-mails-every-2-minutes': {
         'task': 'nuntium.tasks.send_mails_task',
         'schedule': crontab(minute='*/2'),
     },
-    'repsync-popit-apis-every-day': {
+    # Resyncs popit every week
+    'resync-popit-apis-every-week': {
         'task': 'nuntium.tasks.pull_from_popit',
+        'kwargs': {
+            'periodicity': '1W'
+        },
         'schedule': crontab(hour=5, minute=30, day_of_week=1),
+    },
+    # Resyncs popit every day
+    'resync-popit-apis-every-day': {
+        'task': 'nuntium.tasks.pull_from_popit',
+        'kwargs': {
+            'periodicity': '1D'
+        },
+        'schedule': crontab(hour=5, minute=30),
+    },
+    # Resyncs popit twice every day
+    'resync-popit-apis-twice-every-day': {
+        'task': 'nuntium.tasks.pull_from_popit',
+        'kwargs': {
+            'periodicity': '2D'
+        },
+        'schedule': crontab(hour='*/12'),
     },
 }
 # the biggest number of recipients a user can


### PR DESCRIPTION
This PR does:
* Adds a backend endpoint for manually syncing from popit
* Adds  ```periodicity``` for pulling from popit which can be set to: ```Never```, ```Once a day```, ```Twice a day``` and ```Once a week```. Being the default value *Once a week*.

In order for this to close #610, the missing parts are
* [ ] Adds the front end things for a user to change the values per instance.
* [ ] Adds a migration.