### PR TITLE
mini thread widget styling

### DIFF
--- a/nuntium/static/sass/instance/_layout-message.scss
+++ b/nuntium/static/sass/instance/_layout-message.scss
@@ -68,3 +68,87 @@
     margin-right: 0.5em;
   }
 }
+
+.mini-thread {
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  overflow: hidden; // hide the box shadow on children
+  margin-top: 1.5em;
+  background-color: #f3f3f3;
+}
+
+.mini-thread__message {
+  display: block;
+
+  // We assume messages are greyed out,
+  // unless we're told they're --selected
+  color: $gray-light;
+  padding: 0.8em 1em;
+
+  &:hover, &:focus {
+    text-decoration: none;
+    color: $link-color;
+  }
+
+  // The reply in a thread
+  .mini-thread__message + & {
+    position: relative;
+    padding-left: 3em;
+
+    &:before {
+      @extend .fa;
+      content: $fa-var-share;
+      position: absolute;
+      font-size: 1.2em;
+      left: 0.9em;
+      top: 1.1em;
+    }
+  }
+
+  * {
+    margin: 3px 0;
+  }
+
+  & > :first-child {
+    margin-top: 0;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+.mini-thread__message__summary,
+.mini-thread__message__person,
+.mini-thread__message__date {
+  font-size: 0.8em;
+  line-height: 1.4em;
+  color: inherit;
+}
+
+// The message we actually care about in a thread
+.mini-thread__message--selected {
+  color: $gray-dark;
+  padding: 1em;
+  background-color: #fff;
+  box-shadow: 0 0 5px rgba(0,0,0,0.2);
+  position: relative;
+  z-index: 1; // Stack above the other messages in this thread
+
+  &:hover, &:focus {
+    color: $link-color;
+  }
+
+  // Make the summary nice and big
+  .mini-thread__message__summary {
+    font-size: 1em;
+  }
+
+  .mini-thread__message + & {
+    // Replies have no summary, so we style
+    // the person name like a summary instead
+    .mini-thread__message__person {
+      font-size: 1em;
+      font-weight: $headings-font-weight;
+    }
+  }
+}

--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -20,7 +20,7 @@
             <div class="container">
                 <div class="instance-summary__recent">
                     <h2>{% trans "Recent messages" %}</h2>
-                    <p><strong>TODO:</strong> Show recent messages here.</p>
+                    {% include 'thread/message_mini.html' %}
                 </div>
                 <div class="instance-summary__popular">
                     <h2>{% trans "Most popular representatives" %}</h2>

--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -20,7 +20,9 @@
             <div class="container">
                 <div class="instance-summary__recent">
                     <h2>{% trans "Recent messages" %}</h2>
-                    {% include 'thread/message_mini.html' %}
+                    {% for message in recent_messages %}
+                        {% include 'thread/message_mini.html' %}
+                    {% endfor %}
                 </div>
                 <div class="instance-summary__popular">
                     <h2>{% trans "Most popular representatives" %}</h2>

--- a/nuntium/templates/thread/message_mini.html
+++ b/nuntium/templates/thread/message_mini.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+
+<!-- A thread where the message of interest is the opening message -->
+<div class="mini-thread">
+  <a href="#" class="mini-thread__message mini-thread__message--selected">
+    <h3 class="mini-thread__message__summary">Request for 2015 expenses</h3>
+    <p class="mini-thread__message__person">To: Alice Brown, Bob Black</p>
+    <p class="mini-thread__message__date">14 March 2015</p>
+  </a>
+  <a href="#" class="mini-thread__message mini-thread__message--reply">
+    <p class="mini-thread__message__person">Reply from Bob Black</p>
+    <p class="mini-thread__message__date">21 March 2015</p>
+  </a>
+</div>
+
+<!-- A thread where the message of interest is one of the replies -->
+<div class="mini-thread">
+  <a href="#" class="mini-thread__message">
+    <h3 class="mini-thread__message__summary">Request for 2015 expenses</h3>
+    <p class="mini-thread__message__person">To: Alice Brown, Bob Black</p>
+  </a>
+  <a href="#" class="mini-thread__message mini-thread__message--reply mini-thread__message--selected">
+    <p class="mini-thread__message__person">Reply from Bob Black</p>
+    <p class="mini-thread__message__date">21 March 2015</p>
+  </a>
+</div>
+
+<!-- A thread where the message of interest is the opening message and it hasn't been replied to -->
+<div class="mini-thread">
+  <a href="#" class="mini-thread__message mini-thread__message--selected">
+    <h3 class="mini-thread__message__summary">Request for 2015 expenses</h3>
+    <p class="mini-thread__message__person">To: Alice Brown, Bob Black</p>
+    <p class="mini-thread__message__date">14 March 2015</p>
+  </a>
+</div>

--- a/nuntium/templates/thread/message_mini.html
+++ b/nuntium/templates/thread/message_mini.html
@@ -1,5 +1,28 @@
 {% load i18n %}
 
+<div class="mini-thread">
+    <a href="{% url 'thread_read' slug=message.slug %}" class="mini-thread__message mini-thread__message--selected">
+        <h3 class="mini-thread__message__summary">{{ message.subject }}</h3>
+        <p class="mini-thread__message__person">To:
+        {% for person in message.people %}{% if not forloop.first and forloop.last %} and {% elif not forloop.first %}, {% endif %}{{ person.name }}{% endfor %}
+        </p>
+        {% if message.created %}
+        <p class="mini-thread__message__date">{{ message.created }}</p>
+        {% endif %}
+    </a>
+
+    {% for answer in message.answers.all %}
+    <a href="{% url 'thread_read' slug=message.slug %}" class="mini-thread__message mini-thread__message--reply">
+        <p class="mini-thread__message__person">Reply from {{ answer.person.name }}</p>
+        {% if answer.created %}
+        <p class="mini-thread__message__date">{{ answer.created }}</p>
+        {% endif %}
+    </a>
+    {% endfor %}
+</div>
+
+{% comment %}
+
 <!-- A thread where the message of interest is the opening message -->
 <div class="mini-thread">
   <a href="#" class="mini-thread__message mini-thread__message--selected">
@@ -33,3 +56,5 @@
     <p class="mini-thread__message__date">14 March 2015</p>
   </a>
 </div>
+
+{% endcomment %}

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -63,6 +63,11 @@ class WriteItInstanceDetailView(DetailView):
         self.kwargs['slug'] = request.subdomain
         return super(WriteItInstanceDetailView, self).dispatch(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = super(WriteItInstanceDetailView, self).get_context_data(**kwargs)
+        context['recent_messages'] = self.object.message_set.filter(public=True).order_by('created')[:5]
+        return context
+
 FORMS = [("who", forms.WhoForm),
          ("draft", forms.DraftForm),
          ("preview", forms.PreviewForm)]


### PR DESCRIPTION
This is the same as #641 but against `master` instead of `new_designs`.

---

Fixes #638.

![screen shot 2015-03-26 at 17 48 01](https://cloud.githubusercontent.com/assets/739624/6853057/7b65521e-d3e0-11e4-9790-dad9727958c3.png)

Shown above:

1. A thread where the original message is the thing we're interested in.
2. A thread where one of the replies is the thing we're interested in.
3. A thread where there are no replies (so by default we're interested in the original message).