### PR TITLE
The email parser is will not complain if the email doesn't contain a UUI...

### DIFF
--- a/mailit/bin/handleemail.py
+++ b/mailit/bin/handleemail.py
@@ -11,6 +11,7 @@ from flufl.bounce import all_failures, scan_message
 from mailit.models import RawIncomingEmail
 from nuntium.models import Answer
 from mailit.bin.froide_email_utils import FroideEmailParser
+from mailit.exceptions import CouldNotFindIdentifier
 
 logging.basicConfig(filename='mailing_logger.txt', level=logging.INFO)
 
@@ -151,8 +152,10 @@ class EmailHandler(FroideEmailParser):
         the_recipient = re.sub(r"\n", "", the_recipient)
 
         regex = re.compile(r".*[\+\-](.*)@.*")
-
-        answer.outbound_message_identifier = regex.match(the_recipient).groups()[0]
+        the_match = regex.match(the_recipient)
+        if the_match is None:
+            raise CouldNotFindIdentifier
+        answer.outbound_message_identifier = the_match.groups()[0]
         logging.info("Reading the parts")
         for part in msg.walk():
             logging.info("Part of type " + part.get_content_type())

--- a/mailit/exceptions.py
+++ b/mailit/exceptions.py
@@ -1,0 +1,2 @@
+class CouldNotFindIdentifier(Exception):
+    pass

--- a/mailit/management/commands/handleemail.py
+++ b/mailit/management/commands/handleemail.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.mail.message import EmailMultiAlternatives
 import traceback
 from django.core.files import File
+from mailit.exceptions import CouldNotFindIdentifier
 
 logging.basicConfig(filename='mailing_logger.txt', level=logging.INFO)
 
@@ -64,7 +65,7 @@ class Command(BaseCommand):
         try:
             answer = handler.handle(lines)
             answer.send_back()
-        except AttributeError:
+        except CouldNotFindIdentifier:
             pass
         except:
             tb = traceback.format_exc()

--- a/mailit/management/commands/handleemail.py
+++ b/mailit/management/commands/handleemail.py
@@ -64,6 +64,8 @@ class Command(BaseCommand):
         try:
             answer = handler.handle(lines)
             answer.send_back()
+        except AttributeError:
+            pass
         except:
             tb = traceback.format_exc()
             text_content = "Error the traceback was:\n" + tb


### PR DESCRIPTION
...D telling write-it to which message is responding to. Closes #699.

<!---
@huboard:{"order":243.63471603393555,"milestone_order":700,"custom_state":""}
-->
