### PR TITLE
Design tweaks, mostly for message styling

### DIFF
--- a/nuntium/static/sass/instance/_layout-message.scss
+++ b/nuntium/static/sass/instance/_layout-message.scss
@@ -147,7 +147,8 @@
       position: absolute;
       font-size: 1.2em;
       left: 0.9em;
-      top: 1.1em;
+      top: 50%;
+      margin-top: -0.4em;
     }
   }
 

--- a/nuntium/static/sass/instance/_layout-message.scss
+++ b/nuntium/static/sass/instance/_layout-message.scss
@@ -1,5 +1,6 @@
 .message {
-  background-color: #f3f3f3;
+  background-color: #fff;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   padding: 1em;
 
   @media (min-width: $screen-sm) {
@@ -64,6 +65,7 @@
 .message--reply {
   position: relative;
   margin-left: 2em;
+  background-color: mix(#fff, $color-orange-50, 33%);
 
   &:before {
     @extend .fa;
@@ -115,7 +117,7 @@
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   overflow: hidden; // hide the box shadow on children
   margin-top: 1.5em;
-  background-color: #f3f3f3;
+  background-color: $color-orange-50;
 
   &:hover {
     @include translate(0, -2px);

--- a/nuntium/static/sass/instance/_layout-message.scss
+++ b/nuntium/static/sass/instance/_layout-message.scss
@@ -116,6 +116,11 @@
   overflow: hidden; // hide the box shadow on children
   margin-top: 1.5em;
   background-color: #f3f3f3;
+
+  &:hover {
+    @include translate(0, -2px);
+    box-shadow: 0 5px 12px rgba(0,0,0,0.08);
+  }
 }
 
 .mini-thread__message {

--- a/nuntium/static/sass/instance/_layout-results.scss
+++ b/nuntium/static/sass/instance/_layout-results.scss
@@ -1,0 +1,50 @@
+.results {
+  @extend .row;
+  margin-top: 1em;
+  margin-bottom: 1em;
+
+  @media (min-width: $screen-sm) {
+    margin-top: 2em;
+    margin-bottom: 2em;
+  }
+}
+
+.results__messages {
+  @extend .col-sm-8;
+  @extend .col-sm-push-4;
+
+  & > :first-child {
+    margin-top: 0;
+  }
+}
+
+.results__actions {
+  @extend .col-sm-3;
+  @extend .col-sm-pull-8;
+
+  ul {
+    @extend .list-unstyled;
+  }
+
+  li {
+    border-top: 1px solid #eee;
+    padding: 0.5em 0;
+  }
+}
+
+.results__actions__heading {
+  font-size: 0.8em;
+  line-height: 1em;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #bbb;
+  margin: 2em 0 0.8em 0;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.results__actions label {
+  font-weight: normal;
+}

--- a/nuntium/static/sass/instance/_layout-thread.scss
+++ b/nuntium/static/sass/instance/_layout-thread.scss
@@ -23,11 +23,11 @@
 
   ul {
     @extend .list-unstyled;
+  }
 
-    li {
-      border-top: 1px solid #eee;
-      padding: 0.5em 0;
-    }
+  li {
+    border-top: 1px solid #eee;
+    padding: 0.5em 0;
   }
 }
 

--- a/nuntium/static/sass/instance/_layout-write.scss
+++ b/nuntium/static/sass/instance/_layout-write.scss
@@ -31,6 +31,10 @@
 
 .writing-breadcrumb__step--current {
   font-weight: bold;
+
+  &:before {
+    font-weight: normal;
+  }
 }
 
 .writing-step {

--- a/nuntium/static/sass/instance/_layout.scss
+++ b/nuntium/static/sass/instance/_layout.scss
@@ -5,6 +5,7 @@
 @import "layout-write";
 @import "layout-message";
 @import "layout-thread";
+@import "layout-results";
 @import "layout-person";
 
 .dropdown-menu-item {

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -1,11 +1,20 @@
 // Give the illusion of infinitely long footer,
 // by matching footer background to body background.
 body, .site-footer {
-  background-color: #eee;
+  background-color: $color-bluegrey-700;
 }
 
 .site-footer {
-  border-top: 1px solid darken(#eee, 6%);
+  color: $color-bluegrey-300;
+
+  a {
+    color: $color-bluegrey-50;
+
+    &:hover,
+    &:focus {
+      color: #fff;
+    }
+  }
 }
 
 // Then give the main page wrapper the background colour
@@ -14,14 +23,29 @@ body, .site-footer {
   background-color: $body-bg;
 }
 
+// Pages with messages on them have a darker background,
+// so that the white messages stand out.
+.page-contains-messages {
+  .site-content {
+    background-color: $color-bluegrey-50;
+  }
+  .site-header {
+    background-color: #fff;
+  }
+}
+
 .site-alert {
-  background-color: $color-pale-orange;
-  border-bottom-color: mix(#000, $color-pale-orange, 6%);
+  background-color: $color-orange-100;
+  border-bottom-color: mix(#000, $color-orange-100, 6%);
 
   // 1px border to overlap navbar or previous site-alert
   position: relative;
   margin-top: -1px;
-  border-top: 1px solid mix(#000, $color-pale-orange, 6%);
+  border-top: 1px solid mix(#000, $color-orange-100, 6%);
+}
+
+.instance-summary {
+  background-color: $color-bluegrey-50;
 }
 
 .writing-breadcrumb__step {
@@ -39,4 +63,12 @@ body, .site-footer {
 .chosen-container .chosen-results li em {
   font-weight: bold;
   background: none;
+}
+
+.thead__actions__heading {
+  color: $color-bluegrey-300;
+}
+
+.thread__actions li {
+  border-top-color: $color-bluegrey-100;
 }

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -65,10 +65,12 @@ body, .site-footer {
   background: none;
 }
 
-.thead__actions__heading {
+.thead__actions__heading,
+.results__actions__heading {
   color: $color-bluegrey-300;
 }
 
-.thread__actions li {
+.thread__actions li,
+.results__actions li {
   border-top-color: $color-bluegrey-100;
 }

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -58,6 +58,10 @@ body, .site-footer {
 
 .writing-breadcrumb__step--current {
   color: $text-color;
+
+  &:before {
+    color: mix($body-bg, $text-color, 60%);
+  }
 }
 
 .writing-buttons__button--previous {

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -32,6 +32,10 @@ body, .site-footer {
   .site-header {
     background-color: #fff;
   }
+  .writing-buttons__button--previous {
+    background-color: mix(#fff, $color-bluegrey-50, 50%);
+    border-color: $color-bluegrey-100;
+  }
 }
 
 .site-alert {

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -1,7 +1,3 @@
-.btn-google {
-  @include button-variant(#ffffff, $color-google-blue, darken($color-google-blue, 5%));
-}
-
 // Give the illusion of infinitely long footer,
 // by matching footer background to body background.
 body, .site-footer {

--- a/nuntium/static/sass/instance/_variables.scss
+++ b/nuntium/static/sass/instance/_variables.scss
@@ -1,7 +1,6 @@
 $color-orange: #f1c232;
 $color-blue: #428bca;
 $color-pale-orange: #ffe599;
-$color-google-blue: #0266C8;
 
 $font-size-base: 16px; // up from default 14px
 $brand-primary: $color-orange;

--- a/nuntium/static/sass/instance/_variables.scss
+++ b/nuntium/static/sass/instance/_variables.scss
@@ -1,10 +1,19 @@
-$color-orange: #f1c232;
-$color-blue: #428bca;
-$color-pale-orange: #ffe599;
+$color-orange: #FF9800;
+$color-orange-50: #FFF3E0;
+$color-orange-100: #FFE599;
+
+$color-blue: #2196F3;
+
+$color-bluegrey-50: #ECEFF1;
+$color-bluegrey-100: #CFD8DC;
+$color-bluegrey-200: #B0BEC5;
+$color-bluegrey-300: #90A4AE;
+$color-bluegrey-700: #455A64;
 
 $font-size-base: 16px; // up from default 14px
 $brand-primary: $color-orange;
 $link-color: $color-blue;
+$navbar-default-bg: mix(#fff, $color-bluegrey-50, 33%);
 
 $chosen-sprite-path: '/static/img/chosen-sprite.png';
 $chosen-sprite-retina-path: '/static/img/chosen-sprite@2x.png';

--- a/nuntium/templates/base.html
+++ b/nuntium/templates/base.html
@@ -33,7 +33,7 @@
     <![endif]-->
 </head>
 
-<body>
+<body class="{% block body_class %}{% endblock %}">
 
     {% block header %}
     {% endblock header %}

--- a/nuntium/templates/thread/all.html
+++ b/nuntium/templates/thread/all.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load subdomainurls %}
 
+{% block body_class %}page-contains-messages{% endblock %}
+
 {% block content_inner %}
     {% for message in message_list %}
         {% include "thread/message_mini.html" with person_links=True message=message %}

--- a/nuntium/templates/thread/all.html
+++ b/nuntium/templates/thread/all.html
@@ -5,7 +5,32 @@
 {% block body_class %}page-contains-messages{% endblock %}
 
 {% block content_inner %}
-    {% for message in message_list %}
-        {% include "thread/message_mini.html" with person_links=True message=message %}
-    {% endfor %}
+    <div class="results">
+        <div class="results__messages">
+          {% for message in message_list %}
+            {% include "thread/message_mini.html" with message=message %}
+          {% endfor %}
+        </div>
+        <div class="results__actions">
+            <h3 class="results__actions__heading">{% trans "Show messages" %}</h3>
+            <ul>
+                <li class="radio">
+                    <label>
+                        <input type="radio" name="example-radios" checked>
+                        {% trans "All messages" %}
+                    </label>
+                </li>
+                <li class="radio">
+                    <label>
+                        <input type="radio" name="example-radios">
+                        {% trans "Awaiting reply" %}
+                    </label>
+                </li>
+            </ul>
+            <h3 class="results__actions__heading">{% trans "Search messages" %}</h3>
+            <p>
+              <input type="search" class="form-control" placeholder="Search…">
+            </p>
+        </div>
+    </div>
 {% endblock content_inner %}

--- a/nuntium/templates/thread/read.html
+++ b/nuntium/templates/thread/read.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load subdomainurls %}
 
+{% block body_class %}page-contains-messages{% endblock %}
+
 {% block content_inner %}
 
   {% if user_came_via_confirmation_link %}

--- a/nuntium/templates/write/preview.html
+++ b/nuntium/templates/write/preview.html
@@ -1,6 +1,8 @@
 {% extends "base_instance.html" %}
 {% load i18n %}
 
+{% block body_class %}page-contains-messages{% endblock %}
+
 {% block content_inner %}
 
     {% include "write/breadcrumb.html" with current_step=3 %}


### PR DESCRIPTION
The "All messages" page, with an example of the sort of stuff we might put in the sidebar:

![screen shot 2015-04-02 at 16 33 17](https://cloud.githubusercontent.com/assets/739624/6967247/024eb55c-d956-11e4-9575-25740dcaee83.png)

(The "Search" page, once it's done, could use this *exact same template*, since it's basically the same thing – a list of messages.)

The "Thread" page:

![screen shot 2015-04-02 at 16 33 44](https://cloud.githubusercontent.com/assets/739624/6967258/1476e56a-d956-11e4-81bf-598333a7903e.png)

The "Preview message" page:

![screen shot 2015-04-02 at 16 42 32](https://cloud.githubusercontent.com/assets/739624/6967455/5620de8e-d957-11e4-9ca5-12e48556e387.png)

The homepage (that middle section still needs some work!! But it's out of scope for now):

![screen shot 2015-04-02 at 16 36 29](https://cloud.githubusercontent.com/assets/739624/6967326/8022a880-d956-11e4-8146-4b435008a6f2.png)
