### PR TITLE
Commenting out filtering and searching in the threads part.

### DIFF
--- a/nuntium/templates/thread/all.html
+++ b/nuntium/templates/thread/all.html
@@ -12,6 +12,7 @@
           {% endfor %}
         </div>
         <div class="results__actions">
+            {% comment "This is commented out as of #711 but it should probably come back to life once we finish #691 and #690" %}
             <h3 class="results__actions__heading">{% trans "Show messages" %}</h3>
             <ul>
                 <li class="radio">
@@ -27,10 +28,12 @@
                     </label>
                 </li>
             </ul>
+
             <h3 class="results__actions__heading">{% trans "Search messages" %}</h3>
             <p>
               <input type="search" class="form-control" placeholder="Search…">
             </p>
+            {% endcomment %}
         </div>
     </div>
 {% endblock content_inner %}


### PR DESCRIPTION
This hides the filters and search form in the ```/threads``` page.

<!---
@huboard:{"order":703.921875,"milestone_order":748,"custom_state":""}
-->
