### PR TITLE
Convert linebreaks to br tags in message partial

### DIFF
--- a/nuntium/templates/thread/message.html
+++ b/nuntium/templates/thread/message.html
@@ -34,6 +34,6 @@
 
     </dl>
     <div class="message__content">
-        {{ message.content }}
+        {{ message.content|linebreaksbr }}
     </div>
 </div>


### PR DESCRIPTION
This stops it appearing as one big paragraph in the message preview.

Fixes #736 
Fixes #737 