### PR TITLE
Add a list of recipients to the draft screen

### DIFF
--- a/nuntium/templates/write/draft.html
+++ b/nuntium/templates/write/draft.html
@@ -1,5 +1,6 @@
 {% extends "base_instance.html" %}
 {% load i18n %}
+{% load nuntium_tags %}
 
 {% block content_inner %}
 
@@ -8,6 +9,9 @@
     <form class="writing-step" action="" method="post">{% csrf_token %}
         {{ wizard.management_form }}
         {{ form.non_field_errors }}
+        <p class="form-group">
+            <p>{% trans "To" %}: {{ message.persons|join_with_commas }}</p>
+        </p>
         <p class="form-group">
             <label for="id_draft-subject">{% trans "Subject" %}</label>
             {{ form.subject.errors }}

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -103,8 +103,9 @@ class WriteMessageView(NamedUrlSessionWizardView):
             form_obj = self.get_form(step=form_key,
                 data=self.storage.get_step_data(form_key),
                 files=self.storage.get_step_files(form_key))
-            form_obj.is_valid()
-            final_form_list.append(form_obj)
+            if form_obj.is_bound:
+                form_obj.is_valid()
+                final_form_list.append(form_obj)
         data = {}
         [data.update(form.cleaned_data) for form in final_form_list]
         return data
@@ -126,7 +127,7 @@ class WriteMessageView(NamedUrlSessionWizardView):
         context['writeitinstance'] = self.writeitinstance
         if self.steps.current == 'who':
             context['persons'] = self.writeitinstance.persons.all()
-        if self.steps.current == 'preview':
+        if self.steps.current == 'preview' or self.steps.current == 'draft':
             context['message'] = self.get_form_values()
             context['message']['people'] = context['message']['persons']
         return context


### PR DESCRIPTION
This shows who you're writing to on the draft screen, which will become
important once we link directly to the draft screen from a person page.

Fixes #648 

<!---
@huboard:{"order":762.5,"milestone_order":759,"custom_state":""}
-->
