### PR TITLE
Remind users that their message will be made public

### DIFF
--- a/nuntium/static/sass/instance/_layout-write.scss
+++ b/nuntium/static/sass/instance/_layout-write.scss
@@ -116,7 +116,7 @@
 
   small {
     float: right;
-    color: $gray-light;
+    color: $color-bluegrey-300;
     font-size: 0.8em;
     margin-top: 0.2em;
   }
@@ -155,5 +155,31 @@
     content: $fa-var-chevron-left;
     margin-right: 0.5em;
     vertical-align: -1px;
+  }
+}
+
+.privacy-reminder {
+  border-top: 1px solid $color-bluegrey-100;
+  border-bottom: 1px solid $color-bluegrey-100;
+  padding: 1em;
+  margin-top: 1em;
+
+  @media (min-width: $screen-sm) {
+    padding: 1.5em;
+    margin-top: 2em;
+  }
+
+  & > :first-child {
+    margin-top: 0;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+
+  h2 {
+    .fa {
+      margin-right: 0.5em;
+    }
   }
 }

--- a/nuntium/templates/write/draft.html
+++ b/nuntium/templates/write/draft.html
@@ -14,7 +14,10 @@
             {{ form.subject }}
         </p>
         <p class="form-group">
-            <label for="id_draft-content">{% trans "Your message" %}</label>
+            <label for="id_draft-content" class="label-with-hint">
+              {% trans "Your message" %}
+              <small>{% trans "This will be published, with your name, online." %}</small>
+            </label>
             {{ form.content.errors }}
             {{ form.content }}
         </p>
@@ -30,7 +33,7 @@
             <div class="col-sm-6">
                 <p class="form-group">
                     <label for="id_draft-author_email" class="label-with-hint">
-                        Your email
+                        {% trans "Your email" %}
                         <small>{% trans "Nobody will see this, ever." %}</small>
                     </label>
                     {{ form.author_email.errors }}

--- a/nuntium/templates/write/preview.html
+++ b/nuntium/templates/write/preview.html
@@ -10,6 +10,10 @@
     <div class="writing-step">
         <!-- :TODO: break this out into separate template, so we can re-use it on message/thread viewing pages -->
         {% include "thread/message.html" with message=message %}
+        <div class="privacy-reminder">
+          <h2><i class="fa fa-question-circle"></i> {% trans "Are you happy for this message to be made public?" %}</h2>
+          <p>{% trans "Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message, but your email address will be kept secret." %}</p>
+        </div>
         <form action="" method="post">{% csrf_token %}
             {{ wizard.management_form }}
 


### PR DESCRIPTION
Includes a subtle reminder on the Writing page, and a very prominent reminder on the Preview page.

@tmtmtmtm or @MyfanwyNixon might want to tweak the wording.

![screen shot 2015-04-08 at 12 33 51](https://cloud.githubusercontent.com/assets/739624/7044461/8ad67ab0-ddeb-11e4-81b7-593723a1359f.png)

Fixes #730.

<!---
@huboard:{"order":109.4085693359375,"milestone_order":772,"custom_state":""}
-->
