### PR TITLE
Strip newlines from subject before sending

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -512,7 +512,7 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
 
         for subscriber in subscribers:
             msg = EmailMultiAlternatives(
-                subject,
+                subject.strip(),
                 text_content,
                 from_email,
                 [subscriber.email],


### PR DESCRIPTION
Because the subject line is read from a file it contains a newline, we
need to strip this otherwise the email library will throw an error.

Fixes https://github.com/ciudadanointeligente/write-it/issues/775