### PR TITLE
Remove "To" from the way we display message replies

### DIFF
--- a/nuntium/templates/thread/answer.html
+++ b/nuntium/templates/thread/answer.html
@@ -16,15 +16,6 @@
           {% endwith %}
         </dd>
 
-        <dt>{% trans "To" %}</dt>
-        <dd>
-          {% if person_links %}
-            <a href="#" title="{% blocktrans with name=original.author_name %}Show all messages from {{ name }}{% endblocktrans %}">{{ original.author_name }}</a>
-          {% else %}
-            {{ original.author_name }}
-          {% endif %}
-        </dd>
-
         {% if answer.created %}
             <dt>{% trans "Date" %}</dt>
             <dd>{{ answer.created }}</dd>


### PR DESCRIPTION
Fixes #750.

Sorry, can't make a screenshot, but it's dead simple. The "To" line in a reply is gone now, leaving just the "From" (ie: the politician) and their message content.

<!---
@huboard:{"order":106.8046875,"milestone_order":781,"custom_state":""}
-->
