### PR TITLE
Fix pluralisation depending on instance max recipients

### DIFF
--- a/nuntium/templates/write/breadcrumb.html
+++ b/nuntium/templates/write/breadcrumb.html
@@ -3,11 +3,30 @@
 <ul class="writing-breadcrumb">
 
   {% if current_step == 1 %}
-    <li class="writing-breadcrumb__step writing-breadcrumb__step--current">{% trans "Select recipients" %}</li>
+    <li class="writing-breadcrumb__step writing-breadcrumb__step--current">
+        {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
+            Select recipient
+        {% plural %}
+            Select recipients
+        {% endblocktrans %}
+    </li>
   {% elif current_step > 1 and current_step < 4 %}
-    <li class="writing-breadcrumb__step"><a href="{% url 'write_message_step' step='who' %}">{% trans "Select recipients" %}</a></li>
+    <li class="writing-breadcrumb__step">
+        <a href="{% url 'write_message_step' step='who' %}">
+            {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
+                Select recipient
+            {% plural %}
+                Select recipients
+            {% endblocktrans %}
+        </a></li>
   {% else %}
-    <li class="writing-breadcrumb__step">{% trans "Select recipients" %}</li>
+    <li class="writing-breadcrumb__step">
+        {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
+            Select recipient
+        {% plural %}
+            Select recipients
+        {% endblocktrans %}
+    </li>
   {% endif %}
 
   {% if current_step == 2 %}

--- a/nuntium/templates/write/draft.html
+++ b/nuntium/templates/write/draft.html
@@ -47,7 +47,13 @@
         </div>
 
         <p class="writing-buttons">
-            <a class="writing-buttons__button--previous" href="{% url 'write_message_step' step=wizard.steps.prev %}">{% trans "Change recipients" %}</a>
+            <a class="writing-buttons__button--previous" href="{% url 'write_message_step' step=wizard.steps.prev %}">
+                {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
+                    Change recipient
+                {% plural %}
+                    Change recipients
+                {% endblocktrans %}
+            </a>
             <input class="writing-buttons__button--next" type="submit" value="{% trans "Preview message" %}"/>
         </p>
     </form>

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -8,7 +8,7 @@
 {% block extrajs %}
     $(".chosen-person-select").chosen({
       width: '100%',
-      max_selected_options: {{writeitinstance.config.maximum_recipients}},
+      max_selected_options: {{ writeitinstance.config.maximum_recipients }},
       no_results_text: '{% trans "No recipients match" %}',
       placeholder_text_multiple: ' ', // hide placeholder text
       placeholder_text_single: ' ', // hide placeholder text
@@ -23,7 +23,13 @@
     <form class="writing-step" action="" method="post">{% csrf_token %}
         {{ wizard.management_form }}
         <p class="form-group">
-            <label for="id_who-persons">{% trans "Search for recipients by name" %}</label>
+            <label for="id_who-persons">
+                {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
+                    Search for recipient by name
+                {% plural %}
+                    Search for recipients by name
+                {% endblocktrans %}
+            </label>
             {{ form.persons.errors }}
             {{ form.persons }}
         </p>


### PR DESCRIPTION
Depending on how the instance is configured the correct pluralisation of
recipients should be done.

Fixes https://github.com/ciudadanointeligente/write-it/issues/765

<!---
@huboard:{"order":53.40234375,"milestone_order":785,"custom_state":""}
-->
