### PR TITLE
Adding a form_prefix to the for the forms in the message creation wizard

### DIFF
--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -135,6 +135,11 @@ class WriteMessageView(NamedUrlSessionWizardView):
             context['message']['people'] = context['message']['persons']
         return context
 
+    def get_form_prefix(self, *args, **kwargs):
+        prefix = super(WriteMessageView, self).get_form_prefix(*args, **kwargs)
+        prefix += u"_" + self.writeitinstance.slug
+        return prefix
+
 
 class MessageDetailView(DetailView):
     template_name = 'nuntium/message/message_detail.html'


### PR DESCRIPTION
This would set for each form in WriteMessageView a prefix so we can
avoid sharing forms across instances. 

Fixes #715 

<!---
@huboard:{"order":186.908203125,"milestone_order":790,"custom_state":""}
-->
