### PR TITLE
Display message when there are no public messages

### DIFF
--- a/nuntium/templates/thread/all.html
+++ b/nuntium/templates/thread/all.html
@@ -9,6 +9,8 @@
         <div class="results__messages">
           {% for message in message_list %}
             {% include "thread/message_mini.html" with message=message %}
+          {% empty %}
+            <p>There are currently no public messages on this site.</p>
           {% endfor %}
         </div>
         <div class="results__actions">


### PR DESCRIPTION
If the instance doesn't contain any public messages then show a message
informing the user that this is the case.

Fixes https://github.com/ciudadanointeligente/write-it/issues/727