### PR TITLE
Thread boxes depend on public search, not Admin

### DIFF
--- a/nuntium/templates/thread/all.html
+++ b/nuntium/templates/thread/all.html
@@ -12,7 +12,7 @@
           {% endfor %}
         </div>
         <div class="results__actions">
-            {% comment "This is commented out as of #711 but it should probably come back to life once we finish #691 and #690" %}
+            {% comment "This is commented out as of #711 but it should probably come back to life once we finish #789" %}
             <h3 class="results__actions__heading">{% trans "Show messages" %}</h3>
             <ul>
                 <li class="radio">


### PR DESCRIPTION
The comment here points at the wrong Issue: we can put this back when we have public search, which is different from the admin side filtering.

<!---
@huboard:{"order":267.01171875,"milestone_order":793,"custom_state":""}
-->
