### PR TITLE
Only show total public messages if there are private ones

### DIFF
--- a/nuntium/user_section/stats.py
+++ b/nuntium/user_section/stats.py
@@ -11,12 +11,12 @@ class StatsPerInstance(object):
         stats = [
             ('Confirmed public messages', self.public_confirmed_messages),
             ('Public messages with answers', self.public_messages_with_answers),
-            ('Total messages', self.amount_of_messages),
-            ('Total public messages', self.amount_of_public_messages),
         ]
         private_message_count = self.amount_of_private_messages
         if private_message_count:
             stats.append(('Total private messages', private_message_count))
+            stats.append(('Total public messages', self.amount_of_public_messages))
+        stats.append(('Total messages', self.amount_of_messages))
         return stats
 
     @property


### PR DESCRIPTION
On the stats page it doesn't make sense to show a count of public
messages and total messages if there are no private messages and
therefore the counts are the same.

Fixes https://github.com/ciudadanointeligente/write-it/issues/808

<!---
@huboard:{"order":755.0,"milestone_order":814,"custom_state":""}
-->
