### PR TITLE
Issues/773/incomming email replies cut oddly

### DIFF
--- a/mailit/bin/handleemail.py
+++ b/mailit/bin/handleemail.py
@@ -75,6 +75,7 @@ class EmailAnswer(EmailSaveMixin, EmailReportBounceMixin):
         self.content_html = ''
         self.outbound_message_identifier = ''
         self.email_from = ''
+        self.email_to = ''
         self.when = ''
         self.message_id = None  # http://en.wikipedia.org/wiki/Message-ID
         self.requests_session = requests.Session()
@@ -89,6 +90,8 @@ class EmailAnswer(EmailSaveMixin, EmailReportBounceMixin):
         # pattern = '[\w\.-]+@[\w\.-]+'
         # expression = re.compile(pattern)
         # cleaned_content = re.sub(expression, '', cleaned_content)
+        if self.email_to:
+            cleaned_content = cleaned_content.replace(self.email_to, '')
         cleaned_content = re.sub(r'[\w\.-\.+]+@[\w\.-]+', '', cleaned_content)
 
         cleaned_content = cleaned_content.replace(self.outbound_message_identifier, '')

--- a/mailit/tests/email_parser/email_answer_tests.py
+++ b/mailit/tests/email_parser/email_answer_tests.py
@@ -26,10 +26,11 @@ class AnswerHandlerTestCase(TestCase):
 
         email_answer = EmailAnswer()
         self.assertTrue(hasattr(email_answer, 'subject'))
-        self.assertTrue(hasattr(email_answer, 'content_text'))
+        self.assertTrue(hasattr(email_answer, '_content_text'))
         self.assertTrue(hasattr(email_answer, 'content_html'))
         self.assertTrue(hasattr(email_answer, 'outbound_message_identifier'))
         self.assertTrue(hasattr(email_answer, 'email_from'))
+        self.assertTrue(hasattr(email_answer, 'email_to'))
         self.assertTrue(hasattr(email_answer, 'when'))
         self.assertTrue(hasattr(email_answer, 'message_id'))
         email_answer.subject = 'prueba4'
@@ -37,6 +38,7 @@ class AnswerHandlerTestCase(TestCase):
         email_answer.content_html = '<p>prueba4lafieritaespeluda</p>'
         email_answer.outbound_message_identifier = '8974aabsdsfierapulgosa'
         email_answer.email_from = 'falvarez@votainteligente.cl'
+        email_answer.email_to = 'Felipe <instance-slug+8974aabsdsfierapulgosa@writeit.org>'
         email_answer.when = 'Wed Jun 26 21:05:33 2013'
         email_answer.message_id = '<CAA5PczfGfdhf29wgK=8t6j7hm8HYsBy8Qg87iTU2pF42Ez3VcQ@mail.gmail.com>'
 
@@ -45,12 +47,12 @@ class AnswerHandlerTestCase(TestCase):
         self.assertEquals(email_answer.content_text, 'prueba4lafieritaespeluda')
         self.assertEquals(email_answer.outbound_message_identifier, '8974aabsdsfierapulgosa')
         self.assertEquals(email_answer.email_from, 'falvarez@votainteligente.cl')
+        self.assertEquals(email_answer.email_to, 'Felipe <instance-slug+8974aabsdsfierapulgosa@writeit.org>')
         self.assertEquals(email_answer.when, 'Wed Jun 26 21:05:33 2013')
         self.assertEquals(email_answer.message_id, '<CAA5PczfGfdhf29wgK=8t6j7hm8HYsBy8Qg87iTU2pF42Ez3VcQ@mail.gmail.com>')
         self.assertEquals(email_answer.content_html, '<p>prueba4lafieritaespeluda</p>')
         self.assertFalse(email_answer.is_bounced)
 
-    @skip("not yet I'm going to do something")
     def test_getter_removes_the_identifier(self):
         email_answer = EmailAnswer()
         email_answer.subject = 'prueba4'
@@ -59,6 +61,20 @@ class AnswerHandlerTestCase(TestCase):
 
         self.assertFalse(email_answer.outbound_message_identifier in email_answer.content_text)
         self.assertNotIn("devteam+@chile.com", email_answer.content_text)
+
+    def test_it_doesnt_contain_anything_of_the_original_email(self):
+        '''If I set the "To" header in the email and use it in the email_answer.recipient
+        then I should not be getting her/his email address in the content'''
+        email_answer = EmailAnswer()
+        email_answer.subject = 'prueba5'
+        email_answer.email_to = 'Tony <instance-2+identifier123@writeit.org>'
+        email_answer.outbound_message_identifier = 'identifier123'
+        email_answer.content_text = '''Thank you for your enquiry. I am completely in favour of this measure,
+and will certainly be voting for it.
+Tony <instance-2+identifier123@writeit.org>:'''
+        self.assertNotIn('<instance-', email_answer.content_text)
+        self.assertNotIn('> :', email_answer.content_text)
+        self.assertNotIn('Tony', email_answer.content_text)
 
     def test_the_email_answer_can_have_attachments(self):
         '''An email answer can have attachments'''

--- a/mailit/tests/email_parser/email_answer_tests.py
+++ b/mailit/tests/email_parser/email_answer_tests.py
@@ -1,5 +1,4 @@
 # coding=utf8
-from django.utils.unittest import skip
 from django.contrib.auth.models import User
 
 from global_test_case import GlobalTestCase as TestCase
@@ -71,7 +70,9 @@ class AnswerHandlerTestCase(TestCase):
         email_answer.outbound_message_identifier = 'identifier123'
         email_answer.content_text = '''Thank you for your enquiry. I am completely in favour of this measure,
 and will certainly be voting for it.
-Tony <instance-2+identifier123@writeit.org>:'''
+Tony 
+<instance-2+identifier123@writeit.org>:'''
+        # There is an intended extra space after the word 'Tony'
         self.assertNotIn('<instance-', email_answer.content_text)
         self.assertNotIn('> :', email_answer.content_text)
         self.assertNotIn('Tony', email_answer.content_text)

--- a/mailit/tests/fixture/mail_from_tony.txt
+++ b/mailit/tests/fixture/mail_from_tony.txt
@@ -1,0 +1,106 @@
+From tony@mytest.org Wed Apr 08 11:13:10 2015
+Received: from mail-perrito.google.com ([209.85.333.33])
+		by localhost with esmtp (Exim 4.82)
+		(envelope-from <tony@mytest.org>)
+		id 1Yfnuw-perroferoz-0d
+		for eduskunta-2+4aaaabbb@writeit.org; Wed, 08 Apr 2015 11:13:10 +0000
+Received: by pabsx10 with SMTP id sx10so111616881pab.3
+        for <eduskunta-2+4aaaabbb@writeit.org>; Wed, 08 Apr 2015 04:13:04 -0700 (PDT)
+        X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20130820;
+        h=x-gm-message-state:mime-version:in-reply-to:references:from:date
+         :message-id:subject:to:content-type:content-transfer-encoding;
+        bh=v+63Sf5uW2Dr+mz5UXgfJz5lTy2JQzYviLj/ygucDtM=;
+        b=br5veRFIRVB/o+asdasd
+         vZEHZyf8LbyJTvlM/asdasd+asdasd/5PXq+asdasd
+         S/asdasd+HYrdQLx6ALuE4f3zdylZGu/QJ/asdasd
+         asdasd/LP6oISEHe6muSWNmM
+         bG2/fCdVgr/aasdasd
+         J15A==
+         X-Gm-Message-State: asdasd
+X-Received: by 10.70.138.38 with SMTP id qn6mr44858211pdb.119.1428491584587;
+ Wed, 08 Apr 2015 04:13:04 -0700 (PDT)
+ MIME-Version: 1.0
+Received: by 10.70.65.233 with HTTP; Wed, 8 Apr 2015 04:12:43 -0700 (PDT)
+In-Reply-To: <123fiera.30633.30436@localhost>
+References: <123fiera.30633.30436@localhost>
+From: Tony Bowden <tony@mytest.org>
+Date: Wed, 8 Apr 2015 12:12:43 +0100
+Message-ID: <CAGEUdFf4QhA8uZ68p-2uiMKhD3J-jp=72FB4Su6wV5FS3AMm0g@mail.gmail.com>
+Subject: Re: [WriteIT] Message: Will you be supporting Bill #19481-9f?
+To: Tony <eduskunta-2+4aaaabbb@writeit.org>
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Thank you for your enquiry. I am completely in favour of this measure,
+and will certainly be voting for it.
+2015-04-07 12:48 GMT+01:00 Tony
+<eduskunta-2+4aaaabbb@writeit.=
+org>:
+> Dear Stubb Alexander
+>
+> You=E2=80=99ve received a message via WriteIt, the online service that al=
+lows
+> anyone to write to politicians and other prominent people.
+>
+>
+> The message is as follows:
+> Subject: Will you be supporting Bill #19481-9f?
+> From: Tony
+> Message body:
+> Maecenas ac nunc eu eros consectetur posuere. Mauris finibus velit id nis=
+i porttitor mollis. Praesent suscipit lacinia sem, mattis placerat mi lobor=
+tis vel. Proin dapibus tellus velit, quis dictum eros venenatis nec. Nunc e=
+nim tortor, porta sit amet molestie vel, tempor quis orci. Sed rhoncus null=
+a risus, non cursus quam tincidunt nec. Aliquam mattis urna ac augue suscip=
+it posuere. Praesent a felis leo. Aenean pellentesque blandit metus ut conv=
+allis. Quisque aliquam sem ut augue vulputate, sed dignissim quam cursus.
+>
+> Sed pellentesque interdum molestie. Aliquam ligula justo, ultrices a nisi=
+ convallis, venenatis interdum ligula. Duis euismod sed dui ut eleifend. Se=
+ d vehicula tortor et interdum eleifend. Aenean nunc ipsum, condimentum inte=
+rdum dignissim posuere, molestie lobortis massa. In facilisis dolor eros, v=
+el vehicula arcu sodales vitae. Interdum et malesuada fames ac ante ipsum p=
+rimis in faucibus. Nunc arcu neque, aliquet ut nisi sed, sodales venenatis =
+odio. Aenean nec diam bibendum augue sodales ullamcorper in vel ligula. Sus=
+pendisse dapibus tristique nibh, non semper sem efficitur sit amet. Integer=
+ ornare pellentesque mollis. Vivamus a orci at libero sollicitudin vulputat=
+ e at dictum turpis. Proin et accumsan ipsum. Mauris arcu elit, efficitur eg=
+et est vel, bibendum rhoncus leo.
+>
+> Etiam cursus ultricies porttitor. Donec ultrices sagittis elit id accumsa=
+n. Morbi at mi elementum, fringilla nisi ac, semper arcu. Sed quis auctor a=
+nte. Praesent eu placerat ex. Donec volutpat sed magna quis consequat. Cras=
+ aliquet fringilla sodales. In sollicitudin mauris varius commodo rutrum. V=
+ estibulum scelerisque arcu a nulla laoreet, in rhoncus elit sagittis. Vivam=
+us pellentesque dapibus mi, eu mollis quam elementum et. Sed ullamcorper si=
+t amet lectus nec tempus. Vivamus consectetur fermentum tortor id commodo. =
+Mauris tincidunt justo eget est bibendum pellentesque.
+>
+> Suspendisse maximus est ac arcu euismod, at faucibus mauris fermentum. Vi=
+vamus facilisis bibendum eros, quis tristique dolor blandit quis. Cras matt=
+is luctus dolor, vel congue tellus eleifend vitae. Proin aliquet convallis =
+facilisis. Ut vitae nibh justo. Duis feugiat lectus eu felis tincidunt tinc=
+idunt. Donec sollicitudin nulla sapien, vitae hendrerit erat efficitur vel.=
+ Vivamus gravida accumsan ultrices. In vehicula, massa sit amet faucibus po=
+ rta, lectus nisl tristique dolor, posuere pretium sapien elit a nibh.
+>
+>
+>
+> You can respond to Tony
+> simply by replying to this email.
+>
+> ** IMPORTANT ** Note that, as well as being sent to
+> Tony,
+> your response will be added to the
+> Eduskunta website at http://writeit.orghttp://edusku=
+nta-2.writeit.org/en/,
+> where it will be public and visible to anyone.
+>
+>
+> If there=E2=80=99s a better email address for you, please let us know at
+> tony@mytest.org,
+> where we=E2=80=99ll also be happy to answer any questions or problems.
+>
+>
+> All the best,
+> The WriteIt team

--- a/mailit/tests/handle_mails_management_command_test.py
+++ b/mailit/tests/handle_mails_management_command_test.py
@@ -2,7 +2,7 @@
 from global_test_case import GlobalTestCase as TestCase
 from django.core.management import call_command
 from ..management.commands.handleemail import AnswerForManageCommand
-from nuntium.models import OutboundMessage, OutboundMessageIdentifier, Answer
+from nuntium.models import OutboundMessage, Answer
 from mock import patch
 from django.core import mail
 from django.test.utils import override_settings
@@ -113,9 +113,10 @@ def readlines4_mock():
 class HandleIncomingEmailCommand(TestCase):
     def setUp(self):
         super(HandleIncomingEmailCommand, self).setUp()
+        self.outbound_message = OutboundMessage.objects.get(id=1)
 
     def test_call_command(self):
-        identifier = OutboundMessageIdentifier.objects.get(id=1)
+        identifier = self.outbound_message.outboundmessageidentifier
         identifier.key = '4aaaabbb'
         identifier.save()
 
@@ -129,7 +130,7 @@ class HandleIncomingEmailCommand(TestCase):
             self.assertEquals(the_answers[0].content, 'prueba4lafieri')
 
     def test_call_command_does_not_include_identifier_in_content(self):
-        identifier = OutboundMessageIdentifier.objects.get(id=1)
+        identifier = self.outbound_message.outboundmessageidentifier
         identifier.key = '4aaaabbb'
         identifier.save()
 
@@ -168,7 +169,7 @@ class HandleIncomingEmailCommand(TestCase):
 
     def test_it_correctly_parses_the_to_email(self):
         '''As described in #773 emails can contain odd parts'''
-        identifier = OutboundMessageIdentifier.objects.get(id=1)
+        identifier = self.outbound_message.outboundmessageidentifier
         identifier.key = '4aaaabbb'
         identifier.save()
         with patch('sys.stdin') as stdin:


### PR DESCRIPTION
This eliminates odd parts of the email by removing entirely the "To" header from the content of the email.

So for example if the email came to: ```Felipe <instance1235+key@writeinpublic.org>``` (this is a response email). And the email contains a signature like ```Il giorno 25/mar/2015, alle ore 16:56, Felipe 
<instance1235+key@writeinpublic.org> ha scritto:```. The output will be ```Il giorno 25/mar/2015, alle ore 16:56,   ha scritto:```.

Sometimes in the email content the signature will be cut, for example: 

```
Tony
<the-instance+identifier@writeinpublic.org>
```
This will also remove that signature.

The possible edge case could be when the newlines come between the names for example:
```
To: Tony <the-instance+identifier@writeinpublic.org>
```
and the content goes like: 
```
T
o
ny 
<the-instance+identifier@writeinpublic.org>
```
If that's the case this will not catch that one.

<!---
@huboard:{"order":429.5,"milestone_order":819,"custom_state":""}
-->


Fixes #773 