### PR TITLE
Repoll when admin re-adds a pre-existing PopIt

### DIFF
--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -169,7 +169,7 @@ class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
         cleaned_data = super(RelatePopitInstanceWithWriteItInstance, self).clean(*args, **kwargs)
         if self.writeitinstance.writeitinstancepopitinstancerecord_set.filter(popitapiinstance__url=cleaned_data.get('popit_url')):
             self.relate()
-            raise ValidationError(_("You already have this popit instance relate. But we are updating the database anyway, to pull in any new contacts"))
+            raise ValidationError(_("You have already added this PopIt. But we will fetch the data from it again now."))
         return cleaned_data
 
 

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -168,7 +168,8 @@ class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
     def clean(self, *args, **kwargs):
         cleaned_data = super(RelatePopitInstanceWithWriteItInstance, self).clean(*args, **kwargs)
         if self.writeitinstance.writeitinstancepopitinstancerecord_set.filter(popitapiinstance__url=cleaned_data.get('popit_url')):
-            raise ValidationError(_("You already have this popit instance related"))
+            self.relate()
+            raise ValidationError(_("You already have this popit instance relate. But we are updating the database anyway, to pull in any new contacts"))
         return cleaned_data
 
 

--- a/nuntium/user_section/tests/popit_instance_update_tests.py
+++ b/nuntium/user_section/tests/popit_instance_update_tests.py
@@ -145,6 +145,9 @@ class RelateMyWriteItInstanceWithAPopitInstance(UserSectionTestCase):
         data = {"popit_url": settings.TEST_POPIT_API_URL}
         form = RelatePopitInstanceWithWriteItInstance(data=data, writeitinstance=self.writeitinstance)
         self.assertFalse(form.is_valid())
+        # Ok so because we know that you are trying to update from your previously related popit
+        # rather than creating a new one I now should just check that Benito is here
+        self.assertTrue(self.writeitinstance.persons.filter(name="Benito"))
 
     def test_form_relate(self):
         form = RelatePopitInstanceWithWriteItInstance(data=self.data, writeitinstance=self.writeitinstance)


### PR DESCRIPTION
When an admin tries to re-add a PopIt that is already linked, don't just show an error message, but instead repoll. Per discussion at https://github.com/ciudadanointeligente/write-it/pull/812#issuecomment-91229834

<!---
@huboard:{"order":0.02933478355407715,"milestone_order":826,"custom_state":""}
-->
