### PR TITLE
Reinstate message attachment links on read.html page

### DIFF
--- a/nuntium/static/sass/instance/_layout-message.scss
+++ b/nuntium/static/sass/instance/_layout-message.scss
@@ -62,6 +62,23 @@
   }
 }
 
+.message__attachments {
+  margin-top: 1em;
+
+  .label {
+    font-size: 0.9em;
+    font-weight: normal;
+
+    .glyphicon {
+      font-size: 0.9em;
+    }
+
+    & + .label {
+      margin-left: 1em;
+    }
+  }
+}
+
 .message--reply {
   position: relative;
   margin-left: 2em;

--- a/nuntium/templates/thread/answer.html
+++ b/nuntium/templates/thread/answer.html
@@ -25,4 +25,13 @@
     <div class="message__content">
         {{ answer.content|linebreaksbr }}
     </div>
+
+  {% if answer.attachments.exists %}
+    <div class="message__attachments">
+      {% for attachment in answer.attachments.all %}
+        <a class="label label-primary" href="{% url 'attachment' pk=attachment.pk %}"><span class="glyphicon glyphicon-paperclip" aria-hidden="true"></span> {{attachment.name}}</a>
+      {% endfor %}
+    </div>
+  {% endif %}
+
 </div>


### PR DESCRIPTION
Fixes #830.

Untested with real data. But should look like:

![screen shot 2015-04-10 at 12 26 41](https://cloud.githubusercontent.com/assets/739624/7086821/3baf6b34-df7d-11e4-8f4e-74af63addc06.png)


<!---
@huboard:{"order":839.0,"milestone_order":836,"custom_state":""}
-->
