### PR TITLE
Site Manager: Add link to Recipients page

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -15,7 +15,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">{% trans 'Create a new WriteIt' %}</h4>
+        <h4 class="modal-title">{% trans 'Create a new Site' %}</h4>
       </div>
       <div class="modal-body">
         <form action="{% url 'create_writeit_instance' %}" method="POST" role="form">
@@ -40,7 +40,7 @@
 {% endif %}
 
     <div class="page-header">
-    <h2>{% trans "Your WriteIts" %}</h2>
+    <h2>{% trans "Your Sites" %}</h2>
     </div>
 
 
@@ -92,13 +92,13 @@
 
           </tr>
           {% empty %}
-          <tr><td colspan="3" class="text-center">You have no instances</td></tr>
+          <tr><td colspan="3" class="text-center">You have no sites</td></tr>
           {% endfor %}
         </tbody>
       </table>
 
       <button class="btn btn-primary" data-toggle="modal" data-target="#createNew">
-        {% trans 'Create a new Write-It' %}
+        {% trans 'Create a new Site' %}
       </button>
 
 <script type="text/javascript">

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -53,7 +53,8 @@
             <th width="50%">
               {% trans 'Name' %}
             </th>
-            <th>{% trans 'See all the messages' %}</th>
+            <th>{% trans 'Recipients' %}</th>
+            <th>{% trans 'Messages' %}</th>
             <th>{% trans 'Edit' %}</th>
             <th>{% trans 'Delete' %}</th>
           </tr>
@@ -84,6 +85,7 @@
                     </script>
                 {% endif %}
             </td>
+            <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
             <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
             <td><a href="{% url 'delete_an_instance' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a></td>


### PR DESCRIPTION
Add a new 'Recipients' column to the Site Manager:

![your sites 2015-04-10 at 13 03 02](https://cloud.githubusercontent.com/assets/57483/7087318/00a1486e-df82-11e4-85aa-eb171678e98e.png)

Closes #831

<!---
@huboard:{"order":838.0,"milestone_order":838,"custom_state":""}
-->
