### PR TITLE
Styling for "future replies" message on thread page

### DIFF
--- a/nuntium/static/sass/instance/_layout-thread.scss
+++ b/nuntium/static/sass/instance/_layout-thread.scss
@@ -39,3 +39,11 @@
   color: #bbb;
   margin: 0 0 0.8em 0;
 }
+
+.thread__messages__no-replies {
+  padding: 2em;
+  margin-top: 2em;
+  text-align: center;
+  border: 2px dashed #ccc;
+  border-radius: 0.5em;
+}

--- a/nuntium/templates/thread/read.html
+++ b/nuntium/templates/thread/read.html
@@ -36,7 +36,7 @@
           {% for answer in message.answers.all %}
             {% include "thread/answer.html" with person_links=True answer=answer original=answer.message %}
           {% empty %}
-            <p>{% trans "Future replies will be published here." %}</p>
+            <p class="thread__messages__no-replies">{% trans "Future replies will be published here." %}</p>
           {% endfor %}
         </div>
         <div class="thread__actions">


### PR DESCRIPTION
I noticed [this](https://github.com/ciudadanointeligente/write-it/blob/650bc976141d480d74fb53361be9dd2c54fdc93a/nuntium/templates/thread/read.html#L39) crept in over the last two days, and looked a bit rushed.

This change styles the message so that it looks more like a placeholder for a reply.

![screen shot 2015-04-10 at 13 14 30](https://cloud.githubusercontent.com/assets/739624/7087447/8c21f5d6-df83-11e4-882e-5230c461fad5.png)

<!---
@huboard:{"order":840.0,"milestone_order":841,"custom_state":""}
-->
