### PR TITLE
Disallow negative rate_limits

### DIFF
--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -52,6 +52,7 @@ $(".chosen-person-select").chosen();
           {{advanced_form.allow_messages_using_form}}
       </div>
       <div class="form-group">
+          {{advanced_form.rate_limiter.errors}}
           {{advanced_form.rate_limiter.label_tag}}
           {{advanced_form.rate_limiter}}
       </div>

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -56,6 +56,7 @@ class WriteItInstanceAdvancedUpdateForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(WriteItInstanceAdvancedUpdateForm, self).__init__(*args, **kwargs)
+        self.fields['rate_limiter'].validators.append(validators.MinValueValidator(0))
         self.fields['maximum_recipients'].validators.append(validators.MinValueValidator(1))
         self.fields['maximum_recipients'].validators.append(validators.MaxValueValidator(settings.OVERALL_MAX_RECIPIENTS))
 

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -47,7 +47,7 @@ class WriteItInstanceAdvancedUpdateForm(ModelForm):
         widgets = {
             'moderation_needed_in_all_messages': CheckboxInput(attrs={'class': 'form-control'}),
             'allow_messages_using_form': CheckboxInput(attrs={'class': 'form-control'}),
-            'rate_limiter': NumberInput(attrs={'class': 'form-control'}),
+            'rate_limiter': NumberInput(attrs={'class': 'form-control', 'min': 0}),
             'notify_owner_when_new_answer': CheckboxInput(attrs={'class': 'form-control'}),
             'autoconfirm_api_messages': CheckboxInput(attrs={'class': 'form-control'}),
             'testing_mode': CheckboxInput(attrs={'class': 'form-control'}),

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -169,6 +169,15 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
         self.assertEquals(writeitinstance.config.autoconfirm_api_messages, 1)
         self.assertEquals(writeitinstance.config.maximum_recipients, 7)
 
+    def test_rate_limit_cannot_be_negative(self):
+        url = reverse('writeitinstance_basic_update', subdomain=self.writeitinstance.slug)
+        modified_data = self.data
+        modified_data['rate_limiter'] = -1
+        self.client.login(username=self.owner.username, password='admin')
+        response = self.client.post(url, data=modified_data, follow=True)
+        self.assertTrue(response.context['advanced_form'].errors)
+        self.assertTrue(response.context['advanced_form'].errors['rate_limiter'])
+
     @override_settings(OVERALL_MAX_RECIPIENTS=10)
     def test_max_recipients_cannot_rise_more_than_settings(self):
         '''The max number of recipients in an instance cannot be changed using this form'''


### PR DESCRIPTION
rate_limit should always be above zero.

I’ve added the server-side validation for this, but can’t work out yet how to add an equivalent client-side check to the one on maximum_recipients.

Fixes #840 

<!---
@huboard:{"order":0.14484049379825592}
-->
