### PR TITLE
Make all Message fields compulsory

### DIFF
--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -103,10 +103,10 @@ class DraftForm(ModelForm):
         model = Message
         fields = ['content', 'subject', 'author_name', 'author_email']
         widgets = {
-            'content': Textarea(attrs={'class': 'form-control'}),
-            'subject': TextInput(attrs={'class': 'form-control'}),
-            'author_name': TextInput(attrs={'class': 'form-control'}),
-            'author_email': EmailInput(attrs={'class': 'form-control'}),
+            'content': Textarea(attrs={'class': 'form-control', 'required': True}),
+            'subject': TextInput(attrs={'class': 'form-control', 'required': True}),
+            'author_name': TextInput(attrs={'class': 'form-control', 'required': True}),
+            'author_email': EmailInput(attrs={'class': 'form-control', 'required': True}),
         }
 
 


### PR DESCRIPTION
Add `’required’: True` to all the widgets of the Message writing form
so that we get HTML5 client-side validation, as well as the server-side
validation that already exists.

![required message 2015-04-10 at 14 46 48](https://cloud.githubusercontent.com/assets/57483/7089042/d108a976-df90-11e4-9853-e4516c080394.png)

Closes #820 


<!---
@huboard:{"order":841.0,"milestone_order":843,"custom_state":""}
-->
