### PR TITLE
728: Explain import errors

### DIFF
--- a/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
+++ b/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
@@ -40,7 +40,9 @@ $(".chosen-person-select").chosen();
           <ul class="list-of-data-sources">
             <li class="list-of-data-sources__data-source">
               <h3 class="data-source__title"><a href="{{ record.popitapiinstance.url }}">{{ record.popitapiinstance.url }}</a></h3>
-              <p class="data-source__info"><i class="data-source__status-indicator data-source__status-indicator--{{ record.status }}"></i>{{ record.status }} <span class="muted">&mdash; last updated {{ record.updated }}</span></p>
+              <p class="data-source__info"><i class="data-source__status-indicator data-source__status-indicator--{{ record.status }}"></i>{{ record.status }} 
+                  {% if record.status_explanation %}({{ record.status_explanation }}){% endif %}
+                  <span class="muted">&mdash; last updated {{ record.updated }}</span></p>
               <div class="data-source__controls">
                 <ul>
                   <li><a data-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample">{% trans 'Edit' %}</a></li>


### PR DESCRIPTION
If we have a status_explanation for the polling status, show it:

![source error 2015-04-10 at 15 42 26](https://cloud.githubusercontent.com/assets/57483/7090100/7aefc08a-df98-11e4-853f-eed46f901bec.png)

Fixes #728 


<!---
@huboard:{"order":419.5,"milestone_order":848,"custom_state":""}
-->
