### PR TITLE
583: Improvements to Message Manager

### DIFF
--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -26,7 +26,7 @@
     {% blocktrans count message_count=writeitinstance.message_set.count %}
     <strong>1</strong> message in your WriteIt
     {% plural %}
-    There are <strong>{{ message_count }}</strong> messages in your WriteIt
+    There are <strong>{{ message_count }}</strong> messages 
     {% endblocktrans %}
   </div>
     {% autopaginate message_list %}

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -80,13 +80,12 @@
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
               {% if message.moderated %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been moderated' %}"><i class="glyphicon glyphicon-ok"></i></div>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been approved' %}"><i class="glyphicon glyphicon-ok"></i></div>
               </td>
               {% else %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not been moderated and you can moderate it by clicking here' %}">
-                    <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %}
-                        <button class="btn btn-default btn-sm moderate">{% trans "Moderate"%}</button>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not been moderated — click here to approve it' %}">
+                    <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Approve"%}</button>
                     </form>
                 </div>
               </td>

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -94,7 +94,7 @@
               </td>
               {% else %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not been moderated — click here to approve it' %}">
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated — click here to approve it' %}">
                     <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Approve"%}</button>
                     </form>
                 </div>

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -35,10 +35,10 @@
         <thead>
           <tr>
             <th>{% trans "Message" %}</th>
-            <th class="text-center">{% trans "Public" %}</th>
-            <th class="text-center">{% trans "Confirmed" %}</th>
+            <th class="text-center">{% trans "Public?" %}</th>
+            <th class="text-center">{% trans "Confirmed?" %}</th>
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
-            	<th class="text-center">{% trans "Moderated" %}</th>
+            	<th class="text-center">{% trans "Moderated?" %}</th>
             {% endif %}
             <th class="text-center">{% trans "Replies"%}</th>
             <th class="text-center">{% trans "Make private/public"%}</th>

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -90,12 +90,12 @@
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
               {% if message.moderated %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been approved' %}"><i class="glyphicon glyphicon-ok"></i></div>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been accepted' %}"><i class="glyphicon glyphicon-ok"></i></div>
               </td>
               {% else %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated — click here to approve it' %}">
-                    <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Approve"%}</button>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated — click here to accept it' %}">
+                    <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Accept"%}</button>
                     </form>
                 </div>
               </td>

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -35,12 +35,12 @@
         <thead>
           <tr>
             <th>{% trans "Message" %}</th>
+            <th class="text-center">{% trans "Replies"%}</th>
             <th class="text-center">{% trans "Public?" %}</th>
             <th class="text-center">{% trans "Confirmed?" %}</th>
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
             	<th class="text-center">{% trans "Moderated?" %}</th>
             {% endif %}
-            <th class="text-center">{% trans "Replies"%}</th>
             <th class="text-center">{% trans "Make private/public"%}</th>
           </tr>
         </thead>
@@ -55,6 +55,14 @@
                 {% endblocktrans %}
               </p>
             </td>
+
+            <td class="text-center">
+              {{ message.answers.count }}
+              {% if writeitinstance.config.can_create_answer %}
+                <a data-toggle="modal" data-target="#modal" href="{% url 'create_answer' subdomain=writeitinstance.slug pk=message.pk %}" alt="{% trans "Add"%}"><i class="fa fa-plus"></i></a>
+              {% endif %}
+            </td>
+
             <td class="text-center">
               {% if message.public %}
               <div class="explanation" data-toggle="tooltip" data-placement="left" title="{% trans 'This message can be seen by everyone' %}">
@@ -66,6 +74,7 @@
               </div>
               {% endif %}
             </td>
+
             <td class="text-center">
             {% if message.confirmated %}
               <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'The author has confirmed that this was sent from their email' %}">
@@ -77,6 +86,7 @@
               </div>
             {% endif %}
             </td>
+
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
               {% if message.moderated %}
               <td class="text-center">
@@ -90,15 +100,8 @@
                 </div>
               </td>
               {% endif %}
-
             {% endif %}
 
-            <td class="text-center">
-              {{ message.answers.count  }}
-              {% if writeitinstance.config.can_create_answer %}
-                <a data-toggle="modal" data-target="#modal" href="{% url 'create_answer' subdomain=writeitinstance.slug pk=message.pk %}" alt="{% trans "Add"%}"><i class="fa fa-plus"></i></a>
-              {% endif %}
-            </td>
             <td class="text-center">
                 {% if message.public %}
                 <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message is public, you can make it private by clicking here' %}">

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -24,7 +24,7 @@
   </div>
   <div class="manager-overview">
     {% blocktrans count message_count=writeitinstance.message_set.count %}
-    <strong>1</strong> message in your WriteIt
+    There is <strong>1</strong> message 
     {% plural %}
     There are <strong>{{ message_count }}</strong> messages 
     {% endblocktrans %}


### PR DESCRIPTION
Make it more obvious that the button actively approves the message. (Closes #583)

Whilst here, add ?s to the text headers (`Moderated?` instead of `Moderated`), move the "number of replies" column further left, and remove needless `WriteIt` name. (Improves #827)

![message manager 2015-04-10 at 16 32 38](https://cloud.githubusercontent.com/assets/57483/7091108/56966660-df9f-11e4-980e-391fde31b253.png)

<!---
@huboard:{"order":27.65625,"milestone_order":849,"custom_state":""}
-->
