### PR TITLE
Source Manager: Fix confusing buttons

### DIFF
--- a/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
+++ b/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
@@ -43,16 +43,16 @@ $(".chosen-person-select").chosen();
               <p class="data-source__info"><i class="data-source__status-indicator data-source__status-indicator--{{ record.status }}"></i>{{ record.status }} <span class="muted">&mdash; last updated {{ record.updated }}</span></p>
               <div class="data-source__controls">
                 <ul>
-                  <li><a data-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample">{% trans 'Edit' %}</a></li>
+                  <li><a data-toggle="collapse" href="#collapseExample-{{ record.pk }}" aria-expanded="false" aria-controls="collapseExample">{% trans 'Edit' %}</a></li>
                 </ul>
               </div>
-              <div class="collapse data-source__edit" id="collapseExample">
+              <div class="collapse data-source__edit" id="collapseExample-{{ record.pk }}">
                 <div class="well">
                   <h3>{% trans 'Polling interval' %}</h3>
                   <form class="form-inline update-popit-form" action="{% url 'update-popit-writeit-relation' subdomain=record.writeitinstance.slug pk=record.pk %}" method='POST'>
                     <div class="form-group">
-                      <label for="polling-interval-select">{% trans 'Fetch new data from this source' %}</label>
-                      <select class="form-control" id="polling-interval-select" name="periodicity">
+                      <label for="polling-interval-select-{{ record.pk }}">{% trans 'Fetch new data from this source' %}</label>
+                      <select class="form-control" id="polling-interval-select-{{ record.pk }}" name="periodicity">
                         <option value="--" {% if record.periodicity == "--" %}selected{% endif %}>{% trans 'Never' %}</option>
                         <option value="2D" {% if record.periodicity == "2D" %}selected{% endif %}>{% trans 'Twice a day' %}</option>
                         <option value="1D" {% if record.periodicity == "1D" %}selected{% endif %}>{% trans 'Daily' %}</option>

--- a/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
+++ b/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
@@ -58,13 +58,12 @@ $(".chosen-person-select").chosen();
                         <option value="1D" {% if record.periodicity == "1D" %}selected{% endif %}>{% trans 'Daily' %}</option>
                         <option value="1W" {% if record.periodicity == "1W" %}selected{% endif %}>{% trans 'Weekly' %}</option>
                       </select>
-
-                      </div>
-                      <div class="save-bar">
+                      <button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
+                    </div>
+                    <div class="save-bar">
                        <button class="btn btn-default resync" href="{% url 'resync-from-popit' subdomain=record.writeitinstance.slug popit_api_pk=record.popitapiinstance.pk %}"><i class="glyphicon glyphicon-refresh"></i> {% trans 'Fetch new data now' %}</button>
-                       <button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
-                      </div>
-                      </form>
+                    </div>
+                  </form>
 
                 </div>
               </div>


### PR DESCRIPTION
**NOTE**: This should be merged after 854, as I mistakenly branched off it.



Having the “Fetch new data now” button in-between changing and saving the polling interval is confusing. Move the ‘Save’ button up to beside the interval:

![data source 2015-04-10 at 17 21 47](https://cloud.githubusercontent.com/assets/57483/7092018/68572612-dfa6-11e4-8c25-7be42ae14bda.png)

Fixes #722 



<!---
@huboard:{"order":221.25,"milestone_order":855,"custom_state":""}
-->
