### PR TITLE
Tidy "All Instances" page

### DIFF
--- a/nuntium/templates/nuntium/template_list.html
+++ b/nuntium/templates/nuntium/template_list.html
@@ -26,7 +26,7 @@
     {% paginate %}
   {% else %}
     <p>{% trans "There are no sites yet!" %}</p>
-    <p><a href="#" class="btn btn-primary">{% trans "Create a Site" %}</a></p>
+    <p><a href="{% url 'create_writeit_instance' %}" class="btn btn-primary">{% trans "Create a Site" %}</a></p>
   {% endif %}
 
 {% endblock content %}

--- a/nuntium/templates/nuntium/template_list.html
+++ b/nuntium/templates/nuntium/template_list.html
@@ -7,7 +7,7 @@
 {% block bodyclass %}page-without-sidebar{% endblock bodyclass %}
 {% block content %}
 
-    <h2 class="text-center">{% trans "Current instances of WriteIt" %}</h2>
+    <h2 class="text-center">{% trans "Current Sites" %}</h2>
 
   {% if object_list %}
     {% autopaginate object_list %}
@@ -25,8 +25,8 @@
     </div>
     {% paginate %}
   {% else %}
-    <p>{% trans "There are no instances yet!" %}</p>
-    <p><a href="#" class="btn btn-primary">{% trans "Create a WriteIt instance" %}</a></p>
+    <p>{% trans "There are no sites yet!" %}</p>
+    <p><a href="#" class="btn btn-primary">{% trans "Create a Site" %}</a></p>
   {% endif %}
 
 {% endblock content %}

--- a/nuntium/templates/nuntium/template_list.html
+++ b/nuntium/templates/nuntium/template_list.html
@@ -15,10 +15,11 @@
     <div class="list-group instances-list-group">
       {% for instance in object_list %}
         <a class="list-group-item" href="{% url 'instance_detail' subdomain=instance.slug %}">
-          <h4 class="list-group-item-heading">{{ instance.name }}</h4>
+          <h4 class="list-group-item-heading">{{ instance.name }}
           {% if instance.config.testing_mode %}
-            <p class="list-group-item-text">{% trans 'This instance is in Test Mode. It can only be seen by you and all the messages will go to your email.' %}</p>
+            ({% trans 'Test Mode' %})
           {% endif %}
+          </h4>
         </a>
       {% endfor %}
     </div>


### PR DESCRIPTION

![current sites 2015-04-11 at 18 53 32](https://cloud.githubusercontent.com/assets/57483/7102581/3c5d1a7c-e07c-11e4-815a-958ee205ea0e.png)


- Add a link to the “Create” page (Fixes #832)
- Change “instances” to “sites” (#530)
- Pull “Test Mode” up to beside the instance name (Fixes #852)

It's still pretty ugly, but #395 will require changing this page substantially anyway.

<!---
@huboard:{"order":27.4375,"milestone_order":864,"custom_state":""}
-->
