### PR TITLE
Tidy the "Create a new site" forms

### DIFF
--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -160,9 +160,9 @@ class PopitParsingFormMixin(object):
 
 class WriteItInstanceCreateFormPopitUrl(ModelForm, PopitParsingFormMixin):
     popit_url = URLField(
-        label=_('Url of the popit instance api'),
-        help_text=_("Example: http://popit.master.ciudadanointeligente.org/api/"),
-        required=False,
+        label=_('PopIt URL'),
+        help_text=_("Example: https://eduskunta.popit.mysociety.org/"),
+        required=True,
         )
 
     class Meta:

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <div class="page-header">
-    <h2>{% trans "Create a new WriteIt" %}</h2>
+    <h2>{% trans "Create a new Site" %}</h2>
 </div>
 <form method="POST">
     {% csrf_token %}

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -9,28 +9,6 @@
 
 {% block content %}
 
-<!-- Modal -->
-<div class="modal fade" id="createNew" >
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">{% trans 'Create a new Site' %}</h4>
-      </div>
-      <div class="modal-body">
-        <form action="{% url 'create_writeit_instance' %}" method="POST" role="form">
-          {% csrf_token %}
-          {{ new_instance_form.as_p }}
-          <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</button>
-            <button type="submit" class="btn btn-primary">{% trans 'Submit' %}</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
 {% if messages %}
   <div class="alert alert-info" role="alert">
     {% for message in messages %}
@@ -50,9 +28,7 @@
         <thead>
           <tr>
             <th>{% trans 'Testing mode?' %}</th>
-            <th width="50%">
-              {% trans 'Name' %}
-            </th>
+            <th width="50%">{% trans 'Name' %}</th>
             <th>{% trans 'Recipients' %}</th>
             <th>{% trans 'Messages' %}</th>
             <th>{% trans 'Edit' %}</th>
@@ -97,14 +73,13 @@
         </tbody>
       </table>
 
-      <button class="btn btn-primary" data-toggle="modal" data-target="#createNew">
+      <p class="btn btn-default"><a href="{% url 'create_writeit_instance' %}">
         {% trans 'Create a new Site' %}
-      </button>
+      </a></p>
 
 <script type="text/javascript">
   var go_and_check_status_of_instance = function(url, class_){
     $.get(url, function(status){
-
       if (status.inprogress >= 1){
         setTimeout( go_and_check_status_of_instance, 2000, url, class_)
       }
@@ -113,9 +88,12 @@
       }
     })
   }
+
   $(function () {
     $('[data-toggle="tooltip"]').tooltip()
   })
+
+
 
 </script>
 {% endblock content%}

--- a/nuntium/tests/writeitinstance_newform_tests.py
+++ b/nuntium/tests/writeitinstance_newform_tests.py
@@ -13,8 +13,8 @@ class InstanceCreateFormTestCase(TestCase):
         super(InstanceCreateFormTestCase, self).setUp()
         self.user = User.objects.first()
 
-    def test_instanciate_the_form(self):
-        '''Instanciate the form for creating a writeit instance'''
+    def test_instantiate_the_form(self):
+        '''Instantiate the form for creating a writeit instance'''
         data = {
             'owner': self.user.id,
             'popit_url': settings.TEST_POPIT_API_URL,
@@ -43,16 +43,15 @@ class InstanceCreateFormTestCase(TestCase):
         instance = form.save()
         self.assertTrue(instance.persons.all())
 
-    def test_creating_an_instance_without_popit_url(self):
+    def test_cant_create_an_instance_without_popit_url(self):
         data = {
             'owner': self.user.id,
             'name': "instance",
             "rate_limiter": 0,
             }
         form = WriteItInstanceCreateFormPopitUrl(data)
-        instance = form.save()
+        self.assertFalse(form.is_valid())
 
-        self.assertFalse(instance.persons.all())
 
     def test_it_has_all_the_fields(self):
         """The form for creating a new writeit instance has all the fields"""

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -152,8 +152,8 @@ class AnswerForm(ModelForm):
 
 class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
     popit_url = URLField(
-        label=_('PopIt API URL'),
-        help_text=_("Example: http://popit.master.ciudadanointeligente.org/api/"),
+        label=_('PopIt URL'),
+        help_text=_("Example: https://eduskunta.popit.mysociety.org/"),
         )
 
     def __init__(self, *args, **kwargs):

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -118,6 +118,7 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
             self.owner = kwargs.pop('owner')
         super(WriteItInstanceCreateForm, self).__init__(*args, **kwargs)
         self.fields['popit_url'].widget.attrs['class'] = 'form-control'
+        self.fields['popit_url'].widget.attrs['required'] = True
 
     def save(self, commit=True):
         instance = super(WriteItInstanceCreateForm, self).save(commit=False)

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -110,7 +110,7 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
         model = WriteItInstance
         fields = ('name', 'popit_url')
         widgets = {
-            'name': TextInput(attrs={'class': 'form-control'})
+            'name': TextInput(attrs={'class': 'form-control', 'required': True}),
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Closes #863 

- Make the name and URL both be Required 
- We don't need API URLs — simple PopIt URLs will do
- Use working PopIts as examples
- Don't have a separate Modal form from Sites Manager: just link to the main one
- Use the "Site" terminology instead of WriteIt/Instance

Splitting the form into a two-step process that fetches the Popit's /about page to auto-fill the `name` field doesn't work yet, because CORS. So that half is now #877 

<!---
@huboard:{"order":13.828125,"milestone_order":865,"custom_state":""}
-->
