### PR TITLE
Add the instance_slug to the hidden 'Who'

### DIFF
--- a/nuntium/templates/thread/to.html
+++ b/nuntium/templates/thread/to.html
@@ -24,7 +24,7 @@
             <form action="{% url 'write_message_step' step='who' %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="write_message_view-current_step" value="who">
-                <input type="hidden" name="who-persons" value="{{ person.pk }}">
+                <input type="hidden" name="who_{{ writeitinstance.slug }}-persons" value="{{ person.pk }}">
                 <button type="submit" class="btn btn-primary write-to-this-person">{% trans "Write to this person" %}</button>
             </form>
         </div>


### PR DESCRIPTION
The form prefixes we added in #790 broke the hidden form we use to “Write to this person” on the Recipient page. We need to add the instance_slug to make it work again. Fixes #856

<!---
@huboard:{"order":0.07242024689912796,"milestone_order":870}
-->
