### PR TITLE
Message Creator: Order contacts by name

### DIFF
--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -100,7 +100,7 @@ class WriteMessageView(NamedUrlSessionWizardView):
 
     def get_form_kwargs(self, step):
         if step == 'who':
-            return {'persons_queryset': self.writeitinstance.persons_with_contacts}
+            return {'persons_queryset': self.writeitinstance.persons_with_contacts.order_by('name')}
         else:
             return {}
 


### PR DESCRIPTION
In the “Search for recipients by name” box, order them by name.

Before:

![recipient search 2015-04-11 at 23 57 19](https://cloud.githubusercontent.com/assets/57483/7103597/8f6dffd6-e0a6-11e4-978d-7d88002aa014.png)

After:

![sorted recipient search 2015-04-12 at 00 08 59](https://cloud.githubusercontent.com/assets/57483/7103626/54413502-e0a8-11e4-83b8-e5e0bff03030.png)


Ideally we’d be able to order by them by their PopIt sort_name, but this is better than not ordering them at all.

Closes #872 

<!---
@huboard:{"order":219.5,"milestone_order":873,"custom_state":""}
-->
