### PR TITLE
Recipient Manager: Order contacts by name

### DIFF
--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -56,7 +56,7 @@ class WriteItInstanceContactDetailView(WriteItInstanceDetailBaseView):
 
     def get_context_data(self, **kwargs):
         context = super(WriteItInstanceContactDetailView, self).get_context_data(**kwargs)
-        context['people'] = self.object.persons.all()
+        context['people'] = self.object.persons.order_by('name')
         return context
 
 


### PR DESCRIPTION
Ideally this would be by their `sort_name`, or, if we don’t have that, we should really take into account the language code of the linked PopIt. But this will do for now, at least until #752 gives us filtering options.

Before:

![recipients manager 2015-04-12 at 00 12 00](https://cloud.githubusercontent.com/assets/57483/7103636/950d2d2a-e0a8-11e4-845e-b4c72790272f.png)

After:

![sorted recipient manager 2015-04-12 at 00 23 54](https://cloud.githubusercontent.com/assets/57483/7103669/427e5f5a-e0aa-11e4-9fc1-d448b029a808.png)


Closes #874 

<!---
@huboard:{"order":109.75,"milestone_order":875,"custom_state":""}
-->
