### PR TITLE
Show the maximum recipients on the form

### DIFF
--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -27,7 +27,7 @@
                 {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
                     Search for recipient by name
                 {% plural %}
-                    Search for recipients by name
+                    Search for up to {{counter }} recipients by name
                 {% endblocktrans %}
             </label>
             {{ form.persons.errors }}


### PR DESCRIPTION
When searching for recipients, show how many you can have. Closes #857 

![inform max recipients 2015-04-12 at 02 24 38](https://cloud.githubusercontent.com/assets/57483/7104012/815cebb8-e0bb-11e4-8d8f-9cb148a41dc9.png)


<!---
@huboard:{"order":878.0,"milestone_order":878,"custom_state":""}
-->
