### PR TITLE
Split live sites and test sites

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -39,20 +39,63 @@
   </div>
 {% endif %}
 
-    <div class="page-header">
-    <h2>{% trans "Your Sites" %}</h2>
-    </div>
+      <div class="page-header">
+        <h2>{% trans "Live Sites" %}</h2>
+      </div>
 
-
-    {% autopaginate object_list %}
-    {% paginate %}
+      {% if live_sites %}
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>{% trans 'Testing mode?' %}</th>
-            <th width="50%">
-              {% trans 'Name' %}
-            </th>
+            <th width="50%">{% trans 'Name' %}</th>
+            <th>{% trans 'Recipients' %}</th>
+            <th>{% trans 'Messages' %}</th>
+            <th>{% trans 'Edit' %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for writeitinstance in live_sites %}
+          <tr>
+            <td>
+                <a target='_blank' href="{% url 'instance_detail' subdomain=writeitinstance.slug %}">{{ writeitinstance }} <i class="fa fa-external-link"></i></a>
+                {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
+                    <i class="fa fa-spinner fa-pulse spinner_{{ writeitinstance.pk }}" data-toggle="tooltip" data-placement="left" title="{% trans 'We are currently getting information from popit' %}"></i>
+                    <script type="text/javascript">
+                    $(function(){
+                        go_and_check_status_of_instance("{% url 'pulling_status' subdomain=writeitinstance.slug %}", "spinner_{{ writeitinstance.pk }}")
+                    })
+                    </script>
+                {% endif %}
+            </td>
+            <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
+            <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
+            <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="3" class="text-center">You have no sites</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p>You currently have no live sites.</p>
+      {% endif %}
+
+      {% if test_sites %}
+      <hr />
+      <div class="page-header">
+        <h2>{% trans "Test Sites" %}</h2>
+        <p>
+            {% blocktrans count counter=test_sites.count %}
+                This site is in Test Mode:
+            {% plural %}
+                These sites are in Test Mode:
+            {% endblocktrans %}
+        </p>
+      </div>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th width="50%">{% trans 'Name' %}</th>
             <th>{% trans 'Recipients' %}</th>
             <th>{% trans 'Messages' %}</th>
             <th>{% trans 'Edit' %}</th>
@@ -60,20 +103,8 @@
           </tr>
         </thead>
         <tbody>
-          {% for writeitinstance in object_list %}
+          {% for writeitinstance in test_sites %}
           <tr>
-            <td class="text-center">
-              {% if writeitinstance.config.testing_mode %}
-              <div class="explanation" data-toggle="tooltip" data-placement="left" title="{% trans 'This is in testing mode' %}">
-                <i class="glyphicon glyphicon-ok"></i>
-              </div>
-              {% else %}
-              <div class="explanation" data-toggle="tooltip" data-placement="left" title="{% trans 'This is not in testing mode' %}">
-                <i class="glyphicon glyphicon-remove"></i>
-              </div>
-              {% endif %}
-            </td>
-
             <td>
                 <a target='_blank' href="{% url 'instance_detail' subdomain=writeitinstance.slug %}">{{ writeitinstance }} <i class="fa fa-external-link"></i></a>
                 {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
@@ -89,13 +120,13 @@
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
             <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
             <td><a href="{% url 'delete_an_instance' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a></td>
-
           </tr>
           {% empty %}
           <tr><td colspan="3" class="text-center">You have no sites</td></tr>
           {% endfor %}
         </tbody>
       </table>
+      {% endif %}
 
       <button class="btn btn-primary" data-toggle="modal" data-target="#createNew">
         {% trans 'Create a new Site' %}

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -194,6 +194,8 @@ class YourInstancesView(UserSectionListView):
     def get_context_data(self, **kwargs):
         kwargs = super(YourInstancesView, self).get_context_data(**kwargs)
         kwargs['new_instance_form'] = WriteItInstanceCreateForm()
+        kwargs['live_sites'] = kwargs['object_list'].filter(config__testing_mode=False)
+        kwargs['test_sites'] = kwargs['object_list'].filter(config__testing_mode=True)
         return kwargs
 
 


### PR DESCRIPTION
Show the live sites and test sites separately in the Site Manager.

Before:

![grouped sites 2015-04-12 at 03 39 09](https://cloud.githubusercontent.com/assets/57483/7104177/a27f5100-e0c5-11e4-920c-e8bf0e7a8156.png)

After:

![split sites 2015-04-12 at 03 22 31](https://cloud.githubusercontent.com/assets/57483/7104149/b609d8a0-e0c3-11e4-907b-2e3451417320.png)

Only test sites now have a Delete button (see #751)

It’s important for the Test Sites to get some better explanatory text, as the New User journey will involve them only having a single site, in test mode. The current text is just a placeholder that will remind us to create something better.

NB: I don't really like how much duplication there is in the template, and I’m not entirely convinced that the views.py implementation of this is the right way to go about this at all... It's also a little ugly, but the admin design process should hopefully clean that up.

Closes #880 

<!---
@huboard:{"order":6.9140625,"milestone_order":881,"custom_state":""}
-->
