### PR TITLE
Move the Test Mode banner to the top

### DIFF
--- a/nuntium/templates/nuntium/profiles/status-bar.html
+++ b/nuntium/templates/nuntium/profiles/status-bar.html
@@ -2,6 +2,17 @@
 {% load subdomainurls %}
 {% load staticfiles %}
 
+{% if writeitinstance.config.testing_mode %}
+  <div class="alert alert-info" role="alert">
+      <a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-info-circle"></i> 
+      {% blocktrans %}
+        This instance is in testing mode. 
+        All mails will be sent to you, rather than the representatives.
+      {% endblocktrans %}</a>
+  </div>
+{% endif %}
+
 {% for rec in writeitinstance.writeitinstancepopitinstancerecord_set.all %}
     {% if rec.status == 'inprogress' %}
         <div class="alert alert-warning" role="alert">
@@ -11,14 +22,6 @@
         </div>
     {% endif %}
 {% endfor %}
-{% if writeitinstance.config.testing_mode %}
-  <div class="alert alert-info" role="alert">
-
-      <a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% blocktrans %}
-      <i class="fa fa-info-circle"></i> This instance is in testing mode which means that all mails will go to you.
-      {% endblocktrans %}</a>
-  </div>
-{% endif %}
 
 {% if messages %}
   <div class="alert alert-info" role="alert">


### PR DESCRIPTION

The “Test Mode” banner should always be above other status messages.

Also, tweak the wording to be more in line with the public-facing
equivalent of it.


![reordered banners 2015-04-12 at 10 46 05](https://cloud.githubusercontent.com/assets/57483/7105139/3222e5c0-e101-11e4-95f6-15ebc031f73c.png)

Closes #882 

<!---
@huboard:{"order":110.625,"milestone_order":884,"custom_state":""}
-->
