### PR TITLE
Remove double flash after site creation

### DIFF
--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -21,13 +21,13 @@ $(".chosen-person-select").chosen();
 {% block content %}
 
     <div class="page-header">
-        <h2>{% blocktrans with writeitinstance=writeitinstance %}Editing {{ writeitinstance }}{% endblocktrans %}</h2>
+        <h2>
+          {% blocktrans with writeitinstance=writeitinstance %}Editing {{ writeitinstance }}{% endblocktrans %}
+          {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
+            <i class="fa fa-spinner fa-pulse" data-toggle="tooltip" data-placement="right" title="{% trans 'We are currently fetching data from PopIt' %}"></i>
+          {% endif %}
+        </h2>
     </div>
-      <span>
-        {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
-        {% blocktrans with writeitinstance=writeitinstance %}We are getting information from popit about the people and contacts in this instance{% endblocktrans %}
-        {% endif %}
-      </span>
 
     <form role="form" action="" method="post">
       <div class="form-group">
@@ -78,5 +78,11 @@ $(".chosen-person-select").chosen();
     </form>
 
 
+<script type="text/javascript">
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  })
+</script>
+    
 
 {% endblock content %}


### PR DESCRIPTION
On the Site Manager we currently report if we’re actively fetching data for that instance from PopIt:

![double flash 2015-04-10 at 13 05 59](https://cloud.githubusercontent.com/assets/57483/7087351/6b1ae1fa-df82-11e4-827d-07ffe8d11565.png)

However, all admin pages already report on this in the header bar.

So replace this message with the inprogress spinner:

![inplace spinner 2015-04-12 at 10 59 44](https://cloud.githubusercontent.com/assets/57483/7105181/bb2c1010-e103-11e4-89aa-d81c821994bf.png)


(I suspect we should just be including that line of JS on all admin pages, rather than pulling it individually like this, but’s one for another change. #886)

Closes #839

<!---
@huboard:{"order":885.0,"milestone_order":885,"custom_state":""}
-->
