### PR TITLE
889 Tidy header bar text

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -94,8 +94,8 @@
   {% if writeitinstance and not writeitinstance.config.allow_messages_using_form %}
     <div class="site-alert">
         <div class="container">
-            <h3 class="site-alert__heading">{% trans "This instance is read-only." %}</h3>
-            <p class="site-alert__description">{% trans "You can’t currently create new messages using this WriteIt." %}</p>
+            <h3 class="site-alert__heading">{% trans "This site is read-only." %}</h3>
+            <p class="site-alert__description">{% trans "You can’t currently create new messages using this site." %}</p>
           {% if user.is_authenticated %}
             <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Change this in Settings" %}</a>
           {% endif %}
@@ -104,7 +104,7 @@
   {% elif writeitinstance and not writeitinstance.persons.exists %}
     <div class="site-alert">
         <div class="container">
-            <h3 class="site-alert__heading">{% trans "This instance has no recipients." %}</h3>
+            <h3 class="site-alert__heading">{% trans "This site has no recipients." %}</h3>
             <p class="site-alert__description">{% trans "There is no-one to write to yet. Please check back soon." %}</p>
           {% if user.is_authenticated %}
             <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Import people from PopIt" %}</a>

--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -78,19 +78,6 @@
         </div>
     </header>
 
-  {% if writeitinstance and writeitinstance.config.testing_mode %}
-    <div class="site-alert">
-        <div class="container">
-            <h3 class="site-alert__heading">{% trans "This site is in Test Mode." %}</h3>
-            <p class="site-alert__description">{% trans "Any messages you write will be sent to the site administrator rather than real representatives." %}</p>
-
-            {% if user.is_authenticated %}
-              <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Disable Test Mode in Settings" %}</a>
-            {% endif %}
-        </div>
-    </div>
-  {% endif %}
-
   {% if writeitinstance and not writeitinstance.config.allow_messages_using_form %}
     <div class="site-alert">
         <div class="container">
@@ -108,6 +95,16 @@
             <p class="site-alert__description">{% trans "There is no-one to write to yet. Please check back soon." %}</p>
           {% if user.is_authenticated %}
             <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Import people from PopIt" %}</a>
+          {% endif %}
+        </div>
+    </div>
+  {% elif writeitinstance and writeitinstance.config.testing_mode %}
+    <div class="site-alert">
+        <div class="container">
+            <h3 class="site-alert__heading">{% trans "This site is in Test Mode." %}</h3>
+            <p class="site-alert__description">{% trans "Any messages you write will be sent to the site administrator rather than real representatives." %}</p>
+          {% if user.is_authenticated %}
+            <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Disable Test Mode in Settings" %}</a>
           {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Replace “instance” and “WriteIt” with “Site”.

Also, only show the first message of: “Read Only”, “No Recipients”, “Test Mode” — there’s no point in showing “Test Mode” if either of the others are true.

![read only 2015-04-12 at 11 50 13](https://cloud.githubusercontent.com/assets/57483/7105315/88d96020-e10a-11e4-894b-752fd860b7d3.png)

![no recipients 2015-04-12 at 11 50 03](https://cloud.githubusercontent.com/assets/57483/7105316/88de8334-e10a-11e4-8d58-3eab62f9d479.png)

![test mode 2015-04-12 at 11 50 29](https://cloud.githubusercontent.com/assets/57483/7105314/88d2acd0-e10a-11e4-913a-317bb7abc9e4.png)

Closes #889

<!---
@huboard:{"order":55.3125,"milestone_order":890,"custom_state":""}
-->
