### PR TITLE
Home Page: Hide the "Recent Messages" section if there are none

### DIFF
--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -17,7 +17,7 @@
             </div>
         </div>
 
-      {% if writeitinstance.message_set %}
+      {% if recent_messages %}
         <div class="instance-summary">
             <div class="container">
                 <div class="instance-summary__recent">
@@ -26,7 +26,7 @@
                         {% include 'thread/message_mini.html' %}
                     {% endfor %}
                 </div>
-                {% comment "Commenting Most popular representatives until we have them" %}
+                {% comment "Hiding Most popular representatives until we have them" %}
                 <div class="instance-summary__popular">
                     <h2>{% trans "Most popular representatives" %}</h2>
                     <p><strong>TODO:</strong> Show representatives here.</p>


### PR DESCRIPTION
Don’t show a “Recent Messages” section if there are no messages to display in it. 

![no recent messages 2015-04-13 at 11 58 20](https://cloud.githubusercontent.com/assets/57483/7114367/75ea84e2-e1d4-11e4-9a89-a3f862f48b56.png)


Closes #866

<!---
@huboard:{"order":3.45703125,"milestone_order":896,"custom_state":""}
-->
