### PR TITLE
Issues/661 message template improvements

### DIFF
--- a/mailit/__init__.py
+++ b/mailit/__init__.py
@@ -1,4 +1,6 @@
+import itertools
 import logging
+import textwrap
 
 from django.conf import settings
 from django.core.mail import mail_admins
@@ -12,6 +14,16 @@ from contactos.models import ContactType
 from writeit_utils import escape_dictionary_values
 
 logging.basicConfig(filename="send_mails.log", level=logging.INFO)
+
+
+def process_content(content, indent='    ', width=66):
+    """Take the provided message content. Wrap it at 66 characters, and then
+    indent it by four spaces.
+    """
+    return u'\n'.join([indent + y
+                       for y
+                       in itertools.chain(*[textwrap.wrap(x, width) for x in content.splitlines()])]
+                      )
 
 
 class MailChannel(OutputPlugin):
@@ -39,9 +51,11 @@ class MailChannel(OutputPlugin):
         context = {
             'subject': outbound_message.message.subject,
             'content': outbound_message.message.content,
+            'content_indented': process_content(outbound_message.message.content),
             'person': outbound_message.contact.person.name,
             'author': author_name,
             'writeit_url': full_url,
+            'message_url': outbound_message.message.get_absolute_url(),
             'writeit_name': writeitinstance.name,
             'owner_email': writeitinstance.owner.email,
             }

--- a/mailit/__init__.py
+++ b/mailit/__init__.py
@@ -59,7 +59,7 @@ class MailChannel(OutputPlugin):
             'writeit_name': writeitinstance.name,
             'owner_email': writeitinstance.owner.email,
             }
-        text_content = template.content_template.format(**context)
+        text_content = template.get_content_template().format(**context)
         html_content = template.content_html_template.format(**escape_dictionary_values(context))
         subject = template.subject_template.format(**context)
 

--- a/mailit/forms.py
+++ b/mailit/forms.py
@@ -1,7 +1,8 @@
 from django.forms import ModelForm, TextInput, Textarea
-from .models import MailItTemplate
 from django.forms import ValidationError
 from django.utils.translation import ugettext as _
+
+from mailit.models import MailItTemplate, default_content_template
 
 
 class MailitTemplateForm(ModelForm):
@@ -14,9 +15,15 @@ class MailitTemplateForm(ModelForm):
 
         super(MailitTemplateForm, self).__init__(*args, **kwargs)
 
+        self.initial['content_template'] = self.initial['content_template'] or default_content_template
+
     def save(self, commit=True):
+        if self.cleaned_data['content_template'] == default_content_template:
+            self.cleaned_data['content_template'] = None
+
         template = super(MailitTemplateForm, self).save(commit=False)
         template.writeitinstance = self.writeitinstance
+
         if commit:
             template.save()
         return template

--- a/mailit/migrations/0010_blank_default_content_templates.py
+++ b/mailit/migrations/0010_blank_default_content_templates.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+import re
+
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+def whitespace_ignoring_equal(a, b):
+    def squash(x):
+        return re.sub('\s', '', x)
+
+    return squash(a) == squash(b)
+
+
+old_mailit_text = u'''
+Dear {person}
+
+You’ve received a message via WriteIt, the online service that allows
+anyone to write to politicians and other prominent people.
+
+
+The message is as follows:
+Subject: {subject}
+From: {author}
+Message body:
+{content}
+
+
+You can respond to {author}
+simply by replying to this email.
+
+** IMPORTANT ** Note that, as well as being sent to
+{author},
+your response will be added to the
+{writeit_name} website at {writeit_url},
+where it will be public and visible to anyone.
+
+
+If there’s a better email address for you, please let us know at
+{owner_email},
+where we’ll also be happy to answer any questions or problems.
+
+
+All the best,
+The WriteIt team
+'''
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        new_mailit_text = u''
+
+        for template in orm.MailItTemplate.objects.all():
+            if whitespace_ignoring_equal(old_mailit_text, template.content_template):
+                template.content_template = new_mailit_text
+                template.save()
+            else:
+                print "MANUAL UPDATE NEEDED: {} {} has modified mailit text - ignoring".format(template.writeitinstance.id, template.writeitinstance.name)
+
+    def backwards(self, orm):
+        new_mailit_text = u''
+
+        for template in orm.MailItTemplate.objects.all():
+            if whitespace_ignoring_equal(new_mailit_text, template.content_template):
+                template.content_template = old_mailit_text
+                template.save()
+            else:
+                print "MANUAL UPDATE NEEDED: {} {} has modified mailit text - ignoring".format(template.writeitinstance.id, template.writeitinstance.name)
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'mailit.bouncedmessagerecord': {
+            'Meta': {'object_name': 'BouncedMessageRecord'},
+            'bounce_text': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'mailit.mailittemplate': {
+            'Meta': {'object_name': 'MailItTemplate'},
+            'content_html_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "'{subject}'", 'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'mailit_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'mailit.rawincomingemail': {
+            'Meta': {'object_name': 'RawIncomingEmail'},
+            'answer': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'raw_email'", 'unique': 'True', 'null': 'True', 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2048'}),
+            'problem': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'raw_emails'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['mailit']
+    symmetrical = True

--- a/mailit/models.py
+++ b/mailit/models.py
@@ -13,7 +13,7 @@ content_template = read_template_as_string(
 class MailItTemplate(models.Model):
     subject_template = models.CharField(
         max_length=255,
-        default="[WriteIT] Message: {subject}",
+        default="{subject}",
         help_text=_('You can use {subject}, {content}, {person}, {author}, {writeit_url}, {writeit_name}, and {owner_email}'),
         )
     content_template = models.TextField(

--- a/mailit/models.py
+++ b/mailit/models.py
@@ -1,10 +1,10 @@
 from django.db import models
 from django.db.models.signals import post_save
-from nuntium.models import WriteItInstance, OutboundMessage, read_template_as_string,\
-    Answer
+from nuntium.models import WriteItInstance, OutboundMessage, Answer, read_template_as_string
 from django.utils.translation import ugettext_lazy as _
 
-content_template = read_template_as_string(
+
+default_content_template = read_template_as_string(
     'templates/mailit/mails/content_template.txt',
     file_source_path=__file__,
     )
@@ -17,14 +17,17 @@ class MailItTemplate(models.Model):
         help_text=_('You can use {subject}, {content}, {person}, {author}, {writeit_url}, {writeit_name}, and {owner_email}'),
         )
     content_template = models.TextField(
-        default=content_template,
         help_text=_('You can use {subject}, {content}, {person}, {author}, {writeit_url}, {writeit_name}, and {owner_email}'),
+        blank=True,
         )
     content_html_template = models.TextField(
         blank=True,
         help_text=_('You can use {subject}, {content}, {person}, {author}, {writeit_url}, {writeit_name}, and {owner_email}'),
         )
     writeitinstance = models.OneToOneField(WriteItInstance, related_name='mailit_template')
+
+    def get_content_template(self):
+        return self.content_template or default_content_template
 
 
 def new_write_it_instance(sender, instance, created, **kwargs):

--- a/mailit/templates/mailit/mails/content_template.txt
+++ b/mailit/templates/mailit/mails/content_template.txt
@@ -1,30 +1,14 @@
 Dear {person}
 
-You’ve received a message via WriteIt, the online service that allows
-anyone to write to politicians and other prominent people.
+{author} has sent you the following message via {writeit_name} ({writeit_url})
 
 
-The message is as follows:
-Subject: {subject}
-From: {author}
-Message body:
-{content}
+{content_indented}
 
 
-You can respond to {author}
-simply by replying to this email.
+You should respond to {author} by replying to this email.
 
-** IMPORTANT ** Note that, as well as being sent to
-{author},
-your response will be added to the
-{writeit_name} website at {writeit_url},
-where it will be public and visible to anyone.
+** IMPORTANT ** Note that, as well as being sent to {author}, your response will be published at {message_url}, where it will be public and visible to anyone.
 
+If there’s a better email address for you, please let us know at {owner_email}, where we’ll also be happy to answer any questions or problems.
 
-If there’s a better email address for you, please let us know at
-{owner_email},
-where we’ll also be happy to answer any questions or problems.
-
-
-All the best,
-The WriteIt team

--- a/mailit/tests/handle_mails_management_command_test.py
+++ b/mailit/tests/handle_mails_management_command_test.py
@@ -101,6 +101,7 @@ def readlines2_mock():
 def readlines3_mock():
     return read_lines('mailit/tests/fixture/mail_for_no_message.txt')
 
+
 def killer_mail():
     return 'this should kill the parser!'
 

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -279,7 +279,7 @@ class MailSendingTestCase(TestCase):
 
     def test_template_string_keys(self):
         # template = self.writeitinstance2.mailit_template
-        self.writeitinstance2.mailit_template.content_template += "{author}"
+        self.writeitinstance2.mailit_template.content_template
         self.writeitinstance2.mailit_template.save()
 
         contact3 = Contact.objects.create(

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -74,7 +74,7 @@ class MailTemplateTestCase(TestCase):
 
         template = MailItTemplate.objects.create(writeitinstance=self.writeitinstance2)
 
-        self.assertEquals(template.subject_template, "[WriteIT] Message: {subject}")
+        self.assertEquals(template.subject_template, "{subject}")
         self.assertEquals(template.content_template, self.content_template)
 
     def test_when_creating_a_new_instance_then_a_new_template_is_created_automatically(self):
@@ -88,7 +88,7 @@ class MailTemplateTestCase(TestCase):
             )
 
         self.assertTrue(instance.mailit_template)
-        self.assertEquals(instance.mailit_template.subject_template, "[WriteIT] Message: {subject}")
+        self.assertEquals(instance.mailit_template.subject_template, "{subject}")
         self.assertEquals(instance.mailit_template.content_template, self.content_template)
         self.assertEquals(instance.mailit_template.content_html_template, '')
 
@@ -102,7 +102,7 @@ class MailTemplateTestCase(TestCase):
         instance.save()
 
         self.assertTrue(instance.mailit_template)
-        self.assertEquals(instance.mailit_template.subject_template, "[WriteIT] Message: {subject}")
+        self.assertEquals(instance.mailit_template.subject_template, "{subject}")
         self.assertEquals(instance.mailit_template.content_template, self.content_template)
 
 
@@ -143,7 +143,7 @@ class MailSendingTestCase(TestCase):
         message = mail.outbox[0]
         self.assertFalse(message.alternatives)
         self.assertIsInstance(message, EmailMultiAlternatives)
-        self.assertEquals(message.subject, '[WriteIT] Message: Subject 1')
+        self.assertEquals(message.subject, 'Subject 1')
 
         context = [
             'Subject 1',
@@ -175,7 +175,7 @@ class MailSendingTestCase(TestCase):
         message = mail.outbox[0]
         self.assertEquals(message.alternatives, [(u'<b>HTML here</b>', 'text/html')])
         self.assertIsInstance(message, EmailMultiAlternatives)
-        self.assertEquals(message.subject, '[WriteIT] Message: Subject 1')
+        self.assertEquals(message.subject, 'Subject 1')
 
         context = [
             'Subject 1',

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -64,7 +64,7 @@ class MailTemplateTestCase(TestCase):
         template = MailItTemplate.objects.create(writeitinstance=self.writeitinstance2)
 
         self.assertEquals(template.subject_template, "{subject}")
-        self.assertEquals(template.content_template, self.content_template)
+        self.assertEquals(template.content_template, '')
 
     def test_when_creating_a_new_instance_then_a_new_template_is_created_automatically(self):
         '''
@@ -78,7 +78,7 @@ class MailTemplateTestCase(TestCase):
 
         self.assertTrue(instance.mailit_template)
         self.assertEquals(instance.mailit_template.subject_template, "{subject}")
-        self.assertEquals(instance.mailit_template.content_template, self.content_template)
+        self.assertEquals(instance.mailit_template.content_template, '')
         self.assertEquals(instance.mailit_template.content_html_template, '')
 
 

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -146,8 +146,7 @@ class MailSendingTestCase(TestCase):
         self.assertEquals(message.subject, 'Subject 1')
 
         context = [
-            'Subject 1',
-            'Content 1',
+            '    Content 1',
             'Pedro',
             'Fiera',
             'instance1',
@@ -160,6 +159,23 @@ class MailSendingTestCase(TestCase):
 
         self.assertEquals(len(message.to), 1)
         self.assertIn("pdaire@ciudadanointeligente.org", message.to)
+
+    @override_settings(EMAIL_SUBJECT_PREFIX='[WriteIT]')
+    def test_content_justification(self):
+        activate('en')
+        self.outbound_message1.message.content = """Ar un o lethrau'r Berwyn y ganwyd ac y magwyd Ceiriog.  Gadawodd ei gartref anghysbell a mynyddig pan yn fachgen; a'i hiraeth am fynyddoedd a bugeiliaid bro ei febyd, tra ym mwg a thwrw Manceinion, roddodd fod i'w gan pan ar ei thlysaf ac ar ei thyneraf.
++
++Mab Richard a Phoebe Hughes, Pen y Bryn, Llanarmon Dyffryn Ceiriog, oedd John Ceiriog Hughes.  Ganwyd ef Medi 25ain, 1832.  Aeth i'r ysgol yn Nant y Glog, ger y llan.  Yn lle aros gartref ym Mhen y Bryn i amaethu ac i fugeila wedi gadael yr ysgol, trodd tua Chroesoswallt yn 1848, i swyddfa argraffydd.  Oddiyno, yn 1849, aeth i Fanceinion; ac yno y bu nes y daeth ei enw yn adnabyddus trwy Gymru.  Deffrowyd ei awen gan gapel, a chyfarfod llenyddol, a chwmni rhai, fel Idris Vychan, oedd yn rhoddi pris ar draddodiadau ac alawon Cymru."""
+
+        result_of_sending, fatal_error = self.channel.send(self.outbound_message1)
+
+        self.assertEquals(len(mail.outbox), 1)  # it is sent to one person pointed in the contact
+        message = mail.outbox[0]
+
+        self.assertIn(
+            u"\n    Ar un o lethrau'r Berwyn y ganwyd ac y magwyd Ceiriog.  Gadawodd\n    ei gartref anghysbell a mynyddig pan yn fachgen; a'i hiraeth am\n    fynyddoedd a bugeiliaid bro ei febyd, tra ym mwg a thwrw\n    Manceinion, roddodd fod i'w gan pan ar ei thlysaf ac ar ei\n    thyneraf.\n    +\n    +Mab Richard a Phoebe Hughes, Pen y Bryn, Llanarmon Dyffryn\n    Ceiriog, oedd John Ceiriog Hughes.  Ganwyd ef Medi 25ain, 1832.\n    Aeth i'r ysgol yn Nant y Glog, ger y llan.  Yn lle aros gartref ym\n    Mhen y Bryn i amaethu ac i fugeila wedi gadael yr ysgol, trodd tua\n    Chroesoswallt yn 1848, i swyddfa argraffydd.  Oddiyno, yn 1849,\n    aeth i Fanceinion; ac yno y bu nes y daeth ei enw yn adnabyddus\n    trwy Gymru.  Deffrowyd ei awen gan gapel, a chyfarfod llenyddol, a\n    chwmni rhai, fel Idris Vychan, oedd yn rhoddi pris ar draddodiadau\n    ac alawon Cymru.\n",
+            message.body,
+            )
 
     @override_settings(EMAIL_SUBJECT_PREFIX='[WriteIT]')
     def test_sending_email_with_html(self):
@@ -178,7 +194,6 @@ class MailSendingTestCase(TestCase):
         self.assertEquals(message.subject, 'Subject 1')
 
         context = [
-            'Subject 1',
             'Content 1',
             'Pedro',
             'Fiera',

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -81,19 +81,6 @@ class MailTemplateTestCase(TestCase):
         self.assertEquals(instance.mailit_template.content_template, self.content_template)
         self.assertEquals(instance.mailit_template.content_html_template, '')
 
-    def test_it_only_creates_templates_when_creating_not_when_updating(self):
-        instance = WriteItInstance.objects.create(
-            name=u'instance 234',
-            slug=u'instance-234',
-            owner=self.owner,
-            )
-
-        instance.save()
-
-        self.assertTrue(instance.mailit_template)
-        self.assertEquals(instance.mailit_template.subject_template, "{subject}")
-        self.assertEquals(instance.mailit_template.content_template, self.content_template)
-
 
 class MailSendingTestCase(TestCase):
     def setUp(self):

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -58,17 +58,6 @@ class MailTemplateTestCase(TestCase):
         with codecs.open('mailit/templates/mailit/mails/content_template.txt', 'r', encoding='utf8') as f:
             self.content_template += f.read()
 
-    def test_it_has_a_template(self):
-        self.writeitinstance2.mailit_template.delete()
-        template = MailItTemplate.objects.create(
-            writeitinstance=self.writeitinstance2,
-            subject_template=u"hello somebody %(thing)s",
-            content_template=u"content thing %(another)s asdas",
-            )
-
-        self.assertTrue(template)
-        self.assertEquals(self.writeitinstance2.mailit_template, template)
-
     def test_mailit_template_has_some_default_data(self):
         self.writeitinstance2.mailit_template.delete()
 

--- a/nuntium/user_section/stats.py
+++ b/nuntium/user_section/stats.py
@@ -1,5 +1,4 @@
 from django.db.models import Count
-from django.db.models import Q
 from nuntium.user_section.views import WriteItInstanceDetailBaseView
 
 


### PR DESCRIPTION
Improve the outbound message template to fix #661, and make it so that this is easier in future by not storing templates in the database unless they differ from the default.

Fixes #661 

<!---
@huboard:{"order":0.14484049379825592,"milestone_order":903,"custom_state":""}
-->
