### PR TITLE
Fix flake8 warnings

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -10,7 +10,6 @@ from .plugins import OutputPlugin
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.contrib.auth.models import User
-from django.contrib.sites.models import Site
 import datetime
 from djangoplugins.models import Plugin
 from django.core.mail import EmailMultiAlternatives

--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -110,7 +110,7 @@ urlpatterns = i18n_patterns('',
     url(r'^attachment/(?P<pk>[-\d]+)/$', download_attachment_view, name='attachment'),
     url(r'^manage/', include(managepatterns)),
     url(r'^accounts/logout/$', 'django.contrib.auth.views.logout', kwargs={'next_page': '/'}, name='logout'),
-    
+
     url(r'^help/(?P<section_name>\w+)/?$', HelpView.as_view(), name='help_section'),
     url(r'^help/?$', HelpView.as_view()),
 )

--- a/nuntium/tests/moderation_messages_test.py
+++ b/nuntium/tests/moderation_messages_test.py
@@ -4,7 +4,6 @@ from ..models import Message, WriteItInstance, \
     Moderation, Confirmation, OutboundMessage
 from popit.models import Person
 from django.core import mail
-from django.contrib.sites.models import Site
 from subdomains.utils import reverse
 import datetime
 from mock import patch
@@ -218,7 +217,7 @@ class ModerationMessagesTestCase(TestCase):
         url = reverse('moderation_accept',
             subdomain=self.private_message.writeitinstance.slug,
             kwargs={
-            'slug': self.private_message.moderation.key
+                'slug': self.private_message.moderation.key
             })
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
@@ -234,7 +233,7 @@ class ModerationMessagesTestCase(TestCase):
         expected_url = reverse('moderation_accept',
             self.private_message.writeitinstance.slug,
             kwargs={
-            'slug': self.private_message.moderation.key
+                'slug': self.private_message.moderation.key
             })
         self.assertEquals(self.private_message.moderation.get_success_url(), expected_url)
 
@@ -371,7 +370,7 @@ class ModerationMessagesTestCase(TestCase):
         url = reverse('moderation_accept',
             subdomain=self.private_message.writeitinstance.slug,
             kwargs={
-            'slug': self.private_message.moderation.key
+                'slug': self.private_message.moderation.key
             })
         response = self.client.get(url)
         self.assertEquals(response.status_code, 302)
@@ -390,7 +389,7 @@ class ModerationMessagesTestCase(TestCase):
         url = reverse('moderation_rejected',
             subdomain=self.private_message.writeitinstance.slug,
             kwargs={
-            'slug': self.private_message.moderation.key
+                'slug': self.private_message.moderation.key
             })
         response = self.client.get(url)
         self.assertEquals(response.status_code, 302)

--- a/nuntium/tests/writeitinstance_newform_tests.py
+++ b/nuntium/tests/writeitinstance_newform_tests.py
@@ -52,7 +52,6 @@ class InstanceCreateFormTestCase(TestCase):
         form = WriteItInstanceCreateFormPopitUrl(data)
         self.assertFalse(form.is_valid())
 
-
     def test_it_has_all_the_fields(self):
         """The form for creating a new writeit instance has all the fields"""
         form = WriteItInstanceCreateFormPopitUrl()

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -14,7 +14,6 @@ from django.utils.translation import ugettext as _
 from popit.models import Person
 from ..forms import WriteItInstanceCreateFormPopitUrl, PopitParsingFormMixin
 from django.conf import settings
-from nuntium.popit_api_instance import PopitApiInstance
 
 
 class WriteItInstanceBasicForm(ModelForm):
@@ -35,40 +34,44 @@ class WriteItInstanceBasicForm(ModelForm):
 class WriteItInstanceAnswerNotificationForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'notify_owner_when_new_answer' ]
-        widgets = { 
+        fields = ['notify_owner_when_new_answer']
+        widgets = {
             'notify_owner_when_new_answer': CheckboxInput(attrs={'class': 'form-control'}),
         }
+
 
 class WriteItInstanceWebBasedForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'allow_messages_using_form' ]
-        widgets = { 
+        fields = ['allow_messages_using_form']
+        widgets = {
             'allow_messages_using_form': CheckboxInput(attrs={'class': 'form-control'}),
         }
+
 
 class WriteItInstanceModerationForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'moderation_needed_in_all_messages' ]
-        widgets = { 
+        fields = ['moderation_needed_in_all_messages']
+        widgets = {
             'moderation_needed_in_all_messages': CheckboxInput(attrs={'class': 'form-control'}),
         }
+
 
 class WriteItInstanceApiAutoconfirmForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'autoconfirm_api_messages' ]
-        widgets = { 
+        fields = ['autoconfirm_api_messages']
+        widgets = {
             'autoconfirm_api_messages': CheckboxInput(attrs={'class': 'form-control'}),
         }
+
 
 class WriteItInstanceMaxRecipientsForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'maximum_recipients' ]
-        widgets = { 
+        fields = ['maximum_recipients']
+        widgets = {
             'maximum_recipients': NumberInput(attrs={'class': 'form-control'}),
         }
 
@@ -81,8 +84,8 @@ class WriteItInstanceMaxRecipientsForm(ModelForm):
 class WriteItInstanceRateLimiterForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = [ 'rate_limiter' ]
-        widgets = { 'rate_limiter': NumberInput(attrs={'class': 'form-control', 'min': 0}) }
+        fields = ['rate_limiter']
+        widgets = {'rate_limiter': NumberInput(attrs={'class': 'form-control', 'min': 0})}
 
     def __init__(self, *args, **kwargs):
         super(WriteItInstanceRateLimiterForm, self).__init__(*args, **kwargs)
@@ -206,4 +209,4 @@ class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
 class WriteItPopitUpdateForm(ModelForm):
     class Meta:
         model = WriteitInstancePopitInstanceRecord
-        fields = ['periodicity', ]
+        fields = ['periodicity']

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -8,7 +8,7 @@ from popit.models import Person
 from mailit.forms import MailitTemplateForm
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
 
-from nuntium.models import WriteItInstance, WriteItInstanceConfig, WriteitInstancePopitInstanceRecord
+from nuntium.models import WriteItInstance, WriteitInstancePopitInstanceRecord
 from nuntium.user_section.views import WriteItInstanceUpdateView, WriteItInstanceApiDocsView
 from nuntium.user_section.forms import WriteItInstanceBasicForm, \
     WriteItInstanceCreateForm, \
@@ -132,7 +132,7 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
 
     def test_rate_limit_cannot_be_negative(self):
         url = reverse('writeitinstance_ratelimiter_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'rate_limiter': -1 }
+        modified_data = {'rate_limiter': -1}
         self.client.login(username=self.owner.username, password='admin')
         response = self.client.post(url, data=modified_data, follow=True)
         self.assertTrue(response.context['form'].errors)
@@ -140,95 +140,95 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
 
     def test_change_rate_limit(self):
         url = reverse('writeitinstance_ratelimiter_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'rate_limiter' : 10 }
+        modified_data = {'rate_limiter': 10}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.config.rate_limiter, 10)
 
     def test_turning_moderation_on(self):
         url = reverse('writeitinstance_moderation_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'moderation_needed_in_all_messages': 'on' }
+        modified_data = {'moderation_needed_in_all_messages': 'on'}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertTrue(writeitinstance.config.moderation_needed_in_all_messages)
 
     def test_turning_moderation_off(self):
         url = reverse('writeitinstance_moderation_update', subdomain=self.writeitinstance.slug)
-        modified_data = { }
+        modified_data = {}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertFalse(writeitinstance.config.moderation_needed_in_all_messages)
 
     def test_turning_answer_notification_on(self):
         url = reverse('writeitinstance_answernotification_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'notify_owner_when_new_answer': 'on' }
+        modified_data = {'notify_owner_when_new_answer': 'on'}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertTrue(writeitinstance.config.notify_owner_when_new_answer)
 
     def test_turning_answer_notification_off(self):
         url = reverse('writeitinstance_answernotification_update', subdomain=self.writeitinstance.slug)
-        modified_data = { }
+        modified_data = {}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertFalse(writeitinstance.config.notify_owner_when_new_answer)
 
     def test_turning_web_based_on(self):
         url = reverse('writeitinstance_webbased_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'allow_messages_using_form': 'on' }
+        modified_data = {'allow_messages_using_form': 'on'}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertTrue(writeitinstance.config.allow_messages_using_form)
 
     def test_turning_web_based_off(self):
         url = reverse('writeitinstance_webbased_update', subdomain=self.writeitinstance.slug)
-        modified_data = { }
+        modified_data = {}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertFalse(writeitinstance.config.allow_messages_using_form)
 
     def test_turning_api_autoconfirm_on(self):
         url = reverse('writeitinstance_api_autoconfirm_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'autoconfirm_api_messages': 'on' }
+        modified_data = {'autoconfirm_api_messages': 'on'}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertTrue(writeitinstance.config.autoconfirm_api_messages)
 
     def test_turning_api_autoconfirm_off(self):
         url = reverse('writeitinstance_api_autoconfirm_update', subdomain=self.writeitinstance.slug)
-        modified_data = { }
+        modified_data = {}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertFalse(writeitinstance.config.autoconfirm_api_messages)
 
     def test_set_max_recipients_to_7(self):
         url = reverse('writeitinstance_maxrecipients_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'maximum_recipients': 7 }
+        modified_data = {'maximum_recipients': 7}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.config.maximum_recipients, 7)
 
     def test_set_max_recipients_to_1(self):
         url = reverse('writeitinstance_maxrecipients_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'maximum_recipients': 1 }
+        modified_data = {'maximum_recipients': 1}
         self.client.login(username=self.owner.username, password='admin')
-        response = self.client.post(url, data=modified_data, follow=True)
+        self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.config.maximum_recipients, 1)
 
     def test_set_max_recipients_to_zero(self):
         url = reverse('writeitinstance_maxrecipients_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'maximum_recipients': 0 }
+        modified_data = {'maximum_recipients': 0}
         self.client.login(username=self.owner.username, password='admin')
         response = self.client.post(url, data=modified_data, follow=True)
         self.assertTrue(response.context['form'].errors)
@@ -237,7 +237,7 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
     @override_settings(OVERALL_MAX_RECIPIENTS=10)
     def test_max_recipients_cannot_rise_more_than_settings(self):
         url = reverse('writeitinstance_maxrecipients_update', subdomain=self.writeitinstance.slug)
-        modified_data = { 'maximum_recipients': 11 }
+        modified_data = {'maximum_recipients': 11}
         self.client.login(username=self.owner.username, password='admin')
         response = self.client.post(url, data=modified_data, follow=True)
         self.assertTrue(response.context['form'].errors)
@@ -313,7 +313,6 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
         self.assertEquals(form._meta.model, WriteItInstance)
         self.assertEquals(form._meta.fields, ['name', 'description'])
 
-
     def test_writeitinstance_basic_form_save(self):
         data = {
             'name': 'name 1',
@@ -323,12 +322,9 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
         url = reverse('writeitinstance_basic_update', subdomain=self.writeitinstance.slug)
         c = self.client
         c.login(username=self.owner.username, password='admin')
-
         response = c.post(url, data=data)
-
         # self.assertEquals(response.status_code, 200)
         self.assertRedirects(response, url)
-
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.name, data['name'])
         self.assertEquals(writeitinstance.config.maximum_recipients, data['maximum_recipients'])
@@ -416,10 +412,11 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
         url = reverse('writeitinstance_basic_update', subdomain=self.writeitinstance.slug)
         c = self.client
         c.login(username=self.owner.username, password='admin')
-        response = c.post(url, data=data)
+        c.post(url, data=data)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.name, data['name'])
         self.assertEquals(writeitinstance.description, data['description'])
+
 
 class WriteItInstanceApiDocsTestCase(UserSectionTestCase):
     def setUp(self):

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -392,7 +392,7 @@ class AcceptMessageView(RedirectView):
             writeitinstance__owner=self.request.user
             )
         message.moderate()
-        view_messages.info(self.request, _('The message "%(message)s" has been accepted') % { 'message': message })
+        view_messages.info(self.request, _('The message "%(message)s" has been accepted') % {'message': message})
         return reverse(
             'messages_per_writeitinstance',
             subdomain=message.writeitinstance.slug,
@@ -415,7 +415,7 @@ class RejectMessageView(RedirectView):
         message.public = False
         message.moderated = True
         message.save()
-        view_messages.info(self.request, _('The message "%(message)s" has been rejected') % { 'message': message })
+        view_messages.info(self.request, _('The message "%(message)s" has been rejected') % {'message': message})
         return reverse(
             'messages_per_writeitinstance',
             subdomain=message.writeitinstance.slug,

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -94,7 +94,6 @@ class WriteMessageView(NamedUrlSessionWizardView):
                 return redirect(self.get_step_url(self.steps.first))
         return super(WriteMessageView, self).get(*args, **kwargs)
 
-
     def get_template_names(self):
         return [TEMPLATES[self.steps.current]]
 
@@ -300,8 +299,8 @@ class WriteSignView(TemplateView):
 
 
 class HelpView(TemplateView):
-  def get_template_names(self):
-    if 'section_name' in self.kwargs:
-        return ["help/{}.html".format(self.kwargs['section_name'])]
-    else:
-        return ["help/index.html"]
+    def get_template_names(self):
+        if 'section_name' in self.kwargs:
+            return ["help/{}.html".format(self.kwargs['section_name'])]
+        else:
+            return ["help/index.html"]


### PR DESCRIPTION
Tidy up miscellaneous flake8 problems

The only ones left are in popit-django + one line in an email message in`email_answer_tests.py` that deliberately has a trailing space.