### PR TITLE
Link to public message page where appropriate

### DIFF
--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -35,7 +35,8 @@
         <thead>
           <tr>
             <th>{% trans "Message" %}</th>
-            <th class="text-center">{% trans "Replies"%}</th>
+            <th class="text-center">{% trans "Thread" %}</th>
+            <th class="text-center">{% trans "Replies" %}</th>
             <th class="text-center">{% trans "Public?" %}</th>
             <th class="text-center">{% trans "Confirmed?" %}</th>
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
@@ -48,12 +49,21 @@
           {% for message in message_list %}
           <tr class="message-in-message-list">
             <td>
-              <h3><a href="{% url 'message_detail_private' subdomain=writeitinstance.slug pk=message.pk %}">{{ message.subject }}</a></h3>
+              <h3><a class="explanation" data-toggle="tooltip" data-placement="right" title="{% trans "Link to message admin" %}" 
+                href="{% url 'message_detail_private' subdomain=writeitinstance.slug pk=message.pk %}">{{ message.subject }}</a> </h3>
               <p class="message-in-message-list__meta">
                 {% blocktrans with created=message.created|timesince author_name=message.author_name to=message.people|join_with_commas %}
                   Sent <strong>{{ created }}</strong> ago to <strong>{{ to }}</strong> from <strong>{{ author_name }}</strong>
                 {% endblocktrans %}
               </p>
+            </td>
+
+            <td class="text-center">
+              {% if message.public and message.confirmated %}
+                <a class="explanation" data-toggle="tooltip" data-placement="left" 
+                  title="{% trans "Link to public message" %}" 
+                  href="{% url 'thread_read' slug=message.slug subdomain=message.writeitinstance.slug %}"><i class="fa fa-external-link"></i></a>
+              {% endif %}
             </td>
 
             <td class="text-center">


### PR DESCRIPTION
Add an extra column to the message manager that links to the public page if the message is public and confirmed.

![thread link 2015-04-13 at 21 01 36](https://cloud.githubusercontent.com/assets/57483/7124386/5509a91e-e220-11e4-8011-acdc5058d61b.png)

I suspect I also need to check something to do with moderation, but I don’t know how to do that, as message.moderated only seems to be true for messages that have *actively* been moderated, not ones that didn’t _need_ to be moderated. (And if we need that many checks, we should really just add a new 'visible?' method to the message. We also need to solve this problem on the Admin page for the message.)

I’m also not 100% convinced about adding this as a new column, but putting it beside the subject line doesn’t really work as then you have both the internal and external links side by side with no visual distinction between them. But @wrightmartin will be doing more work on this page tomorrow anyway, so at least this gives him something useful to move to elsewhere...

Closes #919 

<!---
@huboard:{"order":920.0,"milestone_order":920,"custom_state":""}
-->
