### PR TITLE
reorganised admin pages for better experience

### DIFF
--- a/nuntium/static/sass/manager/_layout.scss
+++ b/nuntium/static/sass/manager/_layout.scss
@@ -1,7 +1,13 @@
-// An example of a layout style, using two bootstrap variables.
-@media(min-width: $screen-sm-min){
-  #some-element { padding: $nav-link-padding; }
+.page-header {
+    position: relative;
 }
+
+.page-header__settings-link {
+   position: absolute;
+   right: 0;
+   bottom: 1em;
+}
+
 
 .sidebar {
     @include make-lg-column(2);

--- a/nuntium/static/sass/manager/_style.scss
+++ b/nuntium/static/sass/manager/_style.scss
@@ -84,6 +84,24 @@ label {
     }
 }
 
+.page-header__settings-link {
+    i {
+        font-size: 9px;
+        color: $gray-light;
+        margin-right: 0.5em;
+    }
+}
+
+.settings-group {
+    h3 {
+        font-size: 1.35em;
+        font-weight: bold;
+    }
+    & + .settings-group {
+        margin-top: 2em;
+        border-top: 1px solid $gray-lighter;
+    }
+}
 
 .data-source__title {
     font-size: 1.3125em;

--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -37,6 +37,7 @@ $(function() {
 {% block content %}
   <div class="page-header">
     <h2>{% trans "Recipients" %}</h2>
+    <a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}" class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i> {% trans "Settings" %}</a>
   </div>
   <div class="manager-overview">
     {% blocktrans count person_count=writeitinstance.persons.count %}

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -2,7 +2,7 @@
 {% load subdomainurls %}
 {% load staticfiles %}
   <ul class="navigation__list">
-    <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Basic Update" %}</a></li>
+    <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "About your site" %}</a></li>
     <li class="{% if section == 'writeitinstance_advanced_update' %}active{% endif %}">{% trans "Advanced Update" %}</li>
     <ul>
       <li class="{% if section == 'writeitinstance_moderation_update' %}active{% endif %}"><a href="{% url 'writeitinstance_moderation_update' subdomain=writeitinstance.slug %}">{% trans "Moderation" %}</a></li>

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -6,7 +6,6 @@
     <li class="{% if section == 'writeitinstance_advanced_update' %}active{% endif %}">{% trans "Advanced Update" %}</li>
     <ul>
       <li class="{% if section == 'writeitinstance_moderation_update' %}active{% endif %}"><a href="{% url 'writeitinstance_moderation_update' subdomain=writeitinstance.slug %}">{% trans "Moderation" %}</a></li>
-      <li class="{% if section == 'writeitinstance_maxrecipients_update' %}active{% endif %}"><a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}">{% trans "Maxium Recipients" %}</a></li>
       <li class="{% if section == 'writeitinstance_ratelimiter_update' %}active{% endif %}"><a href="{% url 'writeitinstance_ratelimiter_update' subdomain=writeitinstance.slug %}">{% trans "Rate Limiter" %}</a></li>
       <li class="{% if section == 'writeitinstance_webbased_update' %}active{% endif %}"><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Web Based?" %}</a></li>
     </ul>

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -8,7 +8,6 @@
       <li class="{% if section == 'writeitinstance_moderation_update' %}active{% endif %}"><a href="{% url 'writeitinstance_moderation_update' subdomain=writeitinstance.slug %}">{% trans "Moderation" %}</a></li>
       <li class="{% if section == 'writeitinstance_maxrecipients_update' %}active{% endif %}"><a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}">{% trans "Maxium Recipients" %}</a></li>
       <li class="{% if section == 'writeitinstance_ratelimiter_update' %}active{% endif %}"><a href="{% url 'writeitinstance_ratelimiter_update' subdomain=writeitinstance.slug %}">{% trans "Rate Limiter" %}</a></li>
-      <li class="{% if section == 'writeitinstance_apiautoconfirm_update' %}active{% endif %}"><a href="{% url 'writeitinstance_api_autoconfirm_update' subdomain=writeitinstance.slug %}">{% trans "API Autoconfirm" %}</a></li>
       <li class="{% if section == 'writeitinstance_webbased_update' %}active{% endif %}"><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Web Based?" %}</a></li>
     </ul>
     <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' subdomain=writeitinstance.slug %}">{% trans "Templates" %}</a></li>

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -8,7 +8,6 @@
       <li class="{% if section == 'writeitinstance_moderation_update' %}active{% endif %}"><a href="{% url 'writeitinstance_moderation_update' subdomain=writeitinstance.slug %}">{% trans "Moderation" %}</a></li>
       <li class="{% if section == 'writeitinstance_maxrecipients_update' %}active{% endif %}"><a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}">{% trans "Maxium Recipients" %}</a></li>
       <li class="{% if section == 'writeitinstance_ratelimiter_update' %}active{% endif %}"><a href="{% url 'writeitinstance_ratelimiter_update' subdomain=writeitinstance.slug %}">{% trans "Rate Limiter" %}</a></li>
-      <li class="{% if section == 'writeitinstance_answernotification_update' %}active{% endif %}"><a href="{% url 'writeitinstance_answernotification_update' subdomain=writeitinstance.slug %}">{% trans "Answer Notification" %}</a></li>
       <li class="{% if section == 'writeitinstance_apiautoconfirm_update' %}active{% endif %}"><a href="{% url 'writeitinstance_api_autoconfirm_update' subdomain=writeitinstance.slug %}">{% trans "API Autoconfirm" %}</a></li>
       <li class="{% if section == 'writeitinstance_webbased_update' %}active{% endif %}"><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Web Based?" %}</a></li>
     </ul>

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -21,6 +21,7 @@
 {% block content %}
   <div class="page-header">
     <h2>{% trans "Messages" %}</h2>
+    <a href="{% url 'writeitinstance_answernotification_update' subdomain=writeitinstance.slug %}" class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i> {% trans "Settings" %}</a>
   </div>
   <div class="manager-overview">
     {% blocktrans count message_count=writeitinstance.message_set.count %}

--- a/nuntium/templates/nuntium/profiles/profile-navigation.html
+++ b/nuntium/templates/nuntium/profiles/profile-navigation.html
@@ -4,7 +4,7 @@
 <nav role="navigation" class="sidebar__navigation">
   <ul class="navigation__list">
       <li{% if section == 'account' %} class="active"{% endif %}><a href="{% url 'account' subdomain=None %}">{% trans "Your Profile" %}</a></li>
-  <li{% if section == 'your-instances' %} class="active"{% endif %}><a href="{% url 'your-instances' subdomain=None %}">{% trans "Your WriteIts" %}</a></li>
+  <li{% if section == 'your-instances' %} class="active"{% endif %}><a href="{% url 'your-instances' subdomain=None %}">{% trans "Your sites" %}</a></li>
   {% if writeitinstance %}
     <li>
       <h2 class="navigation__instance-name">{{ writeitinstance.name }}</h2>

--- a/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
@@ -10,22 +10,25 @@
 
 {% block content %}
 
-    <div class="page-header">
-        <h2>{% trans 'Answer Notification' %}</h2>
+      <div class="page-header">
+        <h2>{% trans 'Message settings' %}</h2>
+        <a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to messages" %}</a>
     </div>
 
-    <p>{% blocktrans %}
+
+
+    <form role="form" action="" method="post">
+      <div class="settings-group">
+      <h3>{% trans 'Answer notification' %}</h3>
+        <p class="help-block">{% blocktrans %}
     If you turn on “Answer Notification”, you will receive copies of all
     responses to messages to your email address.
     {% endblocktrans %}</p>
-
-    <form role="form" action="" method="post">
-
-      <div class="form-group">
-        {{form.notify_owner_when_new_answer.label_tag}}
-        {{form.notify_owner_when_new_answer}}
+        <div class="form-group">
+          {{form.notify_owner_when_new_answer.label_tag}}
+          {{form.notify_owner_when_new_answer}}
+        </div>
       </div>
-
       <div class="save-bar">
         <input type="submit" class='btn btn-primary' value="{% trans 'Save changes' %}" />
       </div>

--- a/nuntium/templates/nuntium/writeitinstance_api_docs.html
+++ b/nuntium/templates/nuntium/writeitinstance_api_docs.html
@@ -3,8 +3,12 @@
 {% load subdomainurls %}
 
 {% block content %}
-          <div class="page-header">
+<div class="page-header">
+    <h2>{% trans "API" %}</h2>
+    <a href="{% url 'writeitinstance_api_autoconfirm_update' subdomain=writeitinstance.slug %}" class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i>{% trans "Settings" %}</a>
+  </div>
             <h2>{% trans "Creating a message using the API" %}</h2>
+
             <p>{% trans "To create a message using the API, send a POST request to" %}<br>
             <code>{{ api_base_url }}message/?format=json&username={{ user.username }}&api_key={{ user.api_key.key }}</code><br>
             {% trans "with payload data like" %}<br>
@@ -22,5 +26,5 @@
             }
             </code>
             </p>
-          </div>
+
 {% endblock content %}

--- a/nuntium/templates/nuntium/writeitinstance_autoconfirm_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_autoconfirm_form.html
@@ -11,22 +11,23 @@
 {% block content %}
 
     <div class="page-header">
-        <h2>{% trans 'API Autoconfirm' %}</h2>
+        <h2>{% trans 'API settings' %}</h2>
+        <a href="{% url 'writeitinstance_api_docs' subdomain=writeitinstance.slug %}" class=""><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to API" %}</a>
     </div>
 
-    <p>{% blocktrans %}
-    If you turn on “API Autoconfirm”, any messages created through the
-    API will be automatically Confirmed. If you do this, please ensure 
-    that you confirm the sender's contact details in your application.
-    {% endblocktrans %}</p>
-
     <form role="form" action="" method="post">
-
-      <div class="form-group">
-        {{form.autoconfirm_api_messages.label_tag}}
-        {{form.autoconfirm_api_messages}}
+      <div class="settings-group">
+        <h3>{% trans 'API Autoconfirm' %}</h3>
+        <p class="help-block">{% blocktrans %}
+        If you turn on “API Autoconfirm”, any messages created through the
+        API will be automatically Confirmed. If you do this, please ensure
+        that you confirm the sender's contact details in your application.
+        {% endblocktrans %}</p>
+        <div class="form-group">
+          {{form.autoconfirm_api_messages.label_tag}}
+          {{form.autoconfirm_api_messages}}
+        </div>
       </div>
-
       <div class="save-bar">
         <input type="submit" class='btn btn-primary' value="{% trans 'Save changes' %}" />
       </div>

--- a/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
@@ -11,28 +11,30 @@
 {% block content %}
 
     <div class="page-header">
-        <h2>{% trans 'Maximum Recipients' %}</h2>
+        <h2>{% trans 'Recipients settings' %}</h2>
+        <a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to recipients" %}</a>
     </div>
 
-    <p>{% blocktrans %}
-    Select the maximum number of recipients any individual message can
-    be sent to.
-    {% endblocktrans %}</p>
-
-    <p>{% blocktrans %}
-    This is limited to a maximum of ten recipients per message. If you
-    want to enable sending messages to more people at once, please
-    contact us.
-    {% endblocktrans %}</p>
 
     <form role="form" action="" method="post">
+      <div class="settings-group">
+        <h3>Maximum recipients</h3>
+        <p class="help-block">{% blocktrans %}
+        Select the maximum number of recipients any individual message can
+        be sent to.
+        {% endblocktrans %}</p>
 
-      <div class="form-group">
-        {{form.maximum_recipients.errors}}
-        {{form.maximum_recipients.label_tag}}
-        {{form.maximum_recipients}}
+        <p class="help-block">{% blocktrans %}
+        This is limited to a maximum of ten recipients per message. If you
+        want to enable sending messages to more people at once, please
+        contact us.
+        {% endblocktrans %}</p>
+          <div class="form-group">
+            {{form.maximum_recipients.errors}}
+            {{form.maximum_recipients.label_tag}}
+            {{form.maximum_recipients}}
+          </div>
       </div>
-
       <div class="save-bar">
         <input type="submit" class='btn btn-primary' value="{% trans 'Save changes' %}" />
       </div>

--- a/nuntium/templates/nuntium/writeitinstance_moderation_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_moderation_form.html
@@ -11,22 +11,24 @@
 {% block content %}
 
     <div class="page-header">
-        <h2>{% trans 'Moderation' %}</h2>
+        <h2>{% trans 'Moderation settings' %}</h2>
+        <a href="#"><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to moderation" %}</a>
     </div>
 
-    <p>{% blocktrans %}
-    If you turn on “Moderation” for the site, messages will be sent
-    to you for approval, before being sent to the intended
-    Recipient(s).
-    {% endblocktrans %}</p>
 
     <form role="form" action="" method="post">
-
-      <div class="form-group">
-        {{form.moderation_needed_in_all_messages.label_tag}}
-        {{form.moderation_needed_in_all_messages}}
+      <div class="settings-group">
+        <h3>Moderation</h3>
+        <p class="help-block">{% blocktrans %}
+        If you turn on “Moderation” for the site, messages will be sent
+        to you for approval, before being sent to the intended
+        Recipient(s).
+        {% endblocktrans %}</p>
+        <div class="form-group">
+          {{form.moderation_needed_in_all_messages.label_tag}}
+          {{form.moderation_needed_in_all_messages}}
+        </div>
       </div>
-
       <div class="save-bar">
         <input type="submit" class='btn btn-primary' value="{% trans 'Save changes' %}" />
       </div>

--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -19,7 +19,7 @@
 
     <div class="page-header">
         <h2>
-          {% blocktrans with writeitinstance=writeitinstance %}Editing {{ writeitinstance }}{% endblocktrans %}
+          {% trans "About your site" %}
           {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
             <i class="fa fa-spinner fa-pulse" data-toggle="tooltip" data-placement="right" title="{% trans 'We are currently fetching data from PopIt' %}"></i>
           {% endif %}


### PR DESCRIPTION
**THIS IS WIP PLEASE DON'T MERGE**

- Settings are now grouped into pages, and linked from the relevant screen
- Forms with multiple fields have an improved design
- WIP items that will need looking at
   - URLS (#936)
   - <s>Message settings has multiple fields that aren't set up properly</s>
   - Rename template files to reflect their new purpose
- I have left 'Web based form' option in place, as this may be removed
- 'Moderation settings' page is currently orphaned, until the new moderation page is added

<!---
@huboard:{"order":0.1629455555230379,"milestone_order":935,"custom_state":""}
-->
