### PR TITLE
CommonMiddleware must come after LocaleMiddleware

### DIFF
--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -155,12 +155,12 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'pagination.middleware.PaginationMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.6/ref/middleware/#middleware-ordering.

This could cause get_language to produce the wrong language, and perhaps
be the reason why we sometimes get en-us in urls where we don't want it.

I'm not certain this is going to fix the problem, but this is definitely a change that needs to happen, so please merge it anyway.

<!---
@huboard:{"order":0.10863037034869194,"milestone_order":942,"custom_state":""}
-->
