### PR TITLE
Better explanation of how many people you can write to

### DIFF
--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -27,9 +27,10 @@
         <p class="form-group">
             <label for="id_who-persons">
                 {% blocktrans count counter=writeitinstance.config.maximum_recipients %}
-                    Search for recipient by name
+                    Search for the recipient by name, or select from the drop-down.
                 {% plural %}
-                    Search for up to {{counter }} recipients by name
+                    Search for recipients by name, or select from the drop-down. <br/ ><br />
+                    You can send your message to up to {{ counter }} people.
                 {% endblocktrans %}
             </label>
             {{ form.persons.errors }}


### PR DESCRIPTION
Explicitly say “You can send your message to up to {{ counter }} people” rather than combining it into “Search for up to {{counter }} recipients by name”.

![multiple recipients 2015-04-14 at 16 55 56](https://cloud.githubusercontent.com/assets/57483/7141161/9c6b8122-e2c7-11e4-9ff8-9ea27a8aaa63.png)

Or, if you can only send to one person:

![one recipient 2015-04-14 at 16 56 37](https://cloud.githubusercontent.com/assets/57483/7141160/9c660594-e2c7-11e4-85e4-9173b96fdba4.png)



Fixes #909

<!---
@huboard:{"order":945.0,"milestone_order":947,"custom_state":""}
-->
