### PR TITLE
Hide admin links to Moderation and Rate Limiting

### DIFF
--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -5,8 +5,6 @@
     <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "About your site" %}</a></li>
     <li class="{% if section == 'writeitinstance_advanced_update' %}active{% endif %}">{% trans "Advanced Update" %}</li>
     <ul>
-      <li class="{% if section == 'writeitinstance_moderation_update' %}active{% endif %}"><a href="{% url 'writeitinstance_moderation_update' subdomain=writeitinstance.slug %}">{% trans "Moderation" %}</a></li>
-      <li class="{% if section == 'writeitinstance_ratelimiter_update' %}active{% endif %}"><a href="{% url 'writeitinstance_ratelimiter_update' subdomain=writeitinstance.slug %}">{% trans "Rate Limiter" %}</a></li>
       <li class="{% if section == 'writeitinstance_webbased_update' %}active{% endif %}"><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Web Based?" %}</a></li>
     </ul>
     <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' subdomain=writeitinstance.slug %}">{% trans "Templates" %}</a></li>


### PR DESCRIPTION
We don’t want to link to Moderation or Rate Limiting for now as they’re not ready for public consumption.

The pages will still exist, so that we can tell people individually (with suitable warnings) that they can use them, but we don’t want to make them obvious to normal admins.

Before:

![before 2015-04-14 at 17 19 59](https://cloud.githubusercontent.com/assets/57483/7141600/a11f263a-e2ca-11e4-8bf5-111a702a9abf.png)

After:

![after 2015-04-14 at 17 19 29](https://cloud.githubusercontent.com/assets/57483/7141599/a11e43aa-e2ca-11e4-96a1-5e5ca6d95589.png)

Closes #927 and #933

<!---
@huboard:{"order":944.5,"milestone_order":949,"custom_state":""}
-->
