### PR TITLE
Add settings for web vs API based sites

### DIFF
--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -384,6 +384,12 @@ CELERY_TIMEZONE = TIME_ZONE
 CELERY_ENABLE_UTC = True
 CELERY_CREATE_MISSING_QUEUES = True
 
+# These can be set independently, but most often one will be set to True and
+# the other to False. Setting both to the same boolean value will have
+# undefined behaviour.
+WEB_BASED = True
+API_BASED = False
+
 if TESTING:
     from testing_settings import *  # noqa
 


### PR DESCRIPTION
This just adds the actual settings. We also need to actually use these
settings within the creation process etc so that they make the sites
behave in different ways.

Part of https://github.com/ciudadanointeligente/write-it/issues/679

<!---
@huboard:{"order":0.14031422836706042,"milestone_order":951,"custom_state":""}
-->
