### PR TITLE
751 Disable Instance

### DIFF
--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -3,10 +3,6 @@
 {% load staticfiles %}
   <ul class="navigation__list">
     <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "About your site" %}</a></li>
-    <li class="{% if section == 'writeitinstance_advanced_update' %}active{% endif %}">{% trans "Advanced Update" %}</li>
-    <ul>
-      <li class="{% if section == 'writeitinstance_webbased_update' %}active{% endif %}"><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Web Based?" %}</a></li>
-    </ul>
     <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' subdomain=writeitinstance.slug %}">{% trans "Templates" %}</a></li>
     <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}">{% trans "Recipients" %}</a></li>
     <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}">{% trans "Messages" %}</a></li>

--- a/nuntium/templates/nuntium/profiles/profile-navigation.html
+++ b/nuntium/templates/nuntium/profiles/profile-navigation.html
@@ -4,7 +4,7 @@
 <nav role="navigation" class="sidebar__navigation">
   <ul class="navigation__list">
       <li{% if section == 'account' %} class="active"{% endif %}><a href="{% url 'account' subdomain=None %}">{% trans "Your Profile" %}</a></li>
-  <li{% if section == 'your-instances' %} class="active"{% endif %}><a href="{% url 'your-instances' subdomain=None %}">{% trans "Your sites" %}</a></li>
+  <li{% if section == 'your-instances' %} class="active"{% endif %}><a href="{% url 'your-instances' subdomain=None %}">{% trans "Your Sites" %}</a></li>
   {% if writeitinstance %}
     <li>
       <h2 class="navigation__instance-name">{{ writeitinstance.name }}</h2>

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -29,6 +29,7 @@
             <th>{% trans 'Recipients' %}</th>
             <th>{% trans 'Messages' %}</th>
             <th>{% trans 'Edit' %}</th>
+            <th>{% trans 'Disable' %}</th>
           </tr>
         </thead>
         <tbody>
@@ -48,6 +49,7 @@
             <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
             <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
+            <td><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a></td>
           </tr>
           {% empty %}
           <tr><td colspan="3" class="text-center">You have no sites</td></tr>

--- a/nuntium/templates/nuntium/writeitinstance_web_based_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_web_based_form.html
@@ -11,7 +11,7 @@
 {% block content %}
 
     <div class="page-header">
-        <h2>{% trans 'Allow Form?' %}</h2>
+        <h2>{% trans 'Site Enabled?' %}</h2>
     </div>
 
     <p>{% blocktrans %}


### PR DESCRIPTION
Move the “Web Based?” config option to be a “Disable Site” config on the Site Manager instead. 

Before:
![site manager before 2015-04-14 at 21 47 38](https://cloud.githubusercontent.com/assets/57483/7147054/140e8256-e2f0-11e4-909f-7986700ab960.png)

After:
![site manager after 2015-04-14 at 21 39 00](https://cloud.githubusercontent.com/assets/57483/7147057/14213c84-e2f0-11e4-980f-bf47e2fb86cc.png)

Then rename that form to make it more obvious what it's for (we still need better text for that, but we'll be doing all the admin text tomorrow):

Before:
![allow form 2015-04-14 at 21 51 50](https://cloud.githubusercontent.com/assets/57483/7147127/8aa15330-e2f0-11e4-8a16-fcef31de95a1.png)

After:
![site enabled 2015-04-14 at 21 47 07](https://cloud.githubusercontent.com/assets/57483/7147055/14164f5e-e2f0-11e4-8856-a68ebe54ce7c.png)

This is the last "Advanced" option so we can now remove that section entirely:

Before:
![about before 2015-04-14 at 21 47 49](https://cloud.githubusercontent.com/assets/57483/7147053/140af104-e2f0-11e4-8999-2070a5b6cca0.png)

After:
![about after 2015-04-14 at 21 39 15](https://cloud.githubusercontent.com/assets/57483/7147056/141db078-e2f0-11e4-9064-9d3349b943f1.png)


Closes #751 

<!---
@huboard:{"order":472.07015711418353,"milestone_order":953,"custom_state":""}
-->
