### PR TITLE
Remove link to Test Mode admin setting

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -105,9 +105,6 @@
         <div class="container">
             <h3 class="site-alert__heading">{% trans "This site is in Test Mode." %}</h3>
             <p class="site-alert__description">{% trans "Any messages you write will be sent to the site administrator rather than real representatives." %}</p>
-          {% if user.is_authenticated %}
-            <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Disable Test Mode in Settings" %}</a>
-          {% endif %}
         </div>
     </div>
   {% endif %}


### PR DESCRIPTION
We no longer have an admin setting for Test Mode, so don’t link to it from the public site.

Before:
![test mode settings 2015-04-14 at 21 58 18](https://cloud.githubusercontent.com/assets/57483/7147232/7c6b4324-e2f1-11e4-9e05-ee940c1d6a7a.png)

After:

![test mode settings after 2015-04-14 at 22 02 10](https://cloud.githubusercontent.com/assets/57483/7147332/2293bdc6-e2f2-11e4-9b28-494d62113cdc.png)


Closes #954 

<!---
@huboard:{"order":945.0,"milestone_order":955,"custom_state":""}
-->
