### PR TITLE
Change "Your WriteIts" to "Site Manager" in header bar

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -63,7 +63,7 @@
                             <li>
                                 <a href="{% url 'your-instances' subdomain=None %}">
                                     <span class="glyphicon glyphicon-tasks"></span>
-                                    {% trans "Your WriteIts" %}
+                                    {% trans "Site Manager" %}
                                 </a>
                             </li>
                             <li>

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -59,7 +59,7 @@
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i> {{ user }} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' subdomain=None %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
-                  <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Your WriteIts" %}</a></li>
+                  <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Site Manager" %}</a></li>
                   <li><a href="{% url 'django.contrib.auth.views.logout' %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
                 </ul>
               </li>

--- a/nuntium/templates/base_writeinpublic.html
+++ b/nuntium/templates/base_writeinpublic.html
@@ -59,7 +59,7 @@
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i> {{ user }} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
-                  <li><a href="{% url 'your-instances' %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Your WriteIts" %}</a></li>
+                  <li><a href="{% url 'your-instances' %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Site Manager" %}</a></li>
                   <li><a href="{% url 'django.contrib.auth.views.logout' %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
                 </ul>
               </li>


### PR DESCRIPTION
removing “WriteIt” per #530, but also noting that you’re not going
directly to your Site(s), but to the Manager.

Before:

Back End:
![back header before 2015-04-15 at 08 12 55](https://cloud.githubusercontent.com/assets/57483/7153777/4426e9a4-e347-11e4-86a9-dfea01c703a5.png)

Front End:
![front header before 2015-04-15 at 08 14 07](https://cloud.githubusercontent.com/assets/57483/7153807/70cae190-e347-11e4-8f74-91f3c12517df.png)

After:

Back End:
![back header after 2015-04-15 at 08 12 33](https://cloud.githubusercontent.com/assets/57483/7153785/4f66c1ae-e347-11e4-83b4-9f589a2b52d7.png)

Front End:
![front header after 2015-04-15 at 08 05 36](https://cloud.githubusercontent.com/assets/57483/7153786/4f6d98bc-e347-11e4-9b52-e74024890f54.png)

Closes #956 

<!---
@huboard:{"order":945.5,"milestone_order":957,"custom_state":""}
-->
