### PR TITLE
Recipient manager wording

### DIFF
--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -59,7 +59,9 @@ $(function() {
             <td>{% show_contacts_for person writeitinstance %}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="3" class="text-center">{% trans "There are no People linked from Popit, connect to a data source to add some" %}</td></tr>
+          <tr><td colspan="3" class="text-center">{% trans "There are no People linked from Popit." %} 
+              <a href="{% url 'relate-writeit-popit' subdomain=writeitinstance.slug %}">{% trans "Connect to a data source to add some." %}</a>
+            </td></tr>
           {% endfor %}
         </tbody>
       </table>

--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -68,29 +68,4 @@ $(function() {
       {% paginate %}
 
 
-<!-- Modal -->
-<div class="modal fade" id="addNewContact" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-      </div>
-      <div class="modal-body">
-        ...
-      </div>
-    </div>
-  </div>
-</div>
-
-<script type="text/javascript">
-var loadAddNewContactModal = function(url, title){
-  console.log(title)
-  $('#myModalLabel').text(title)
-  $('.modal-body').load(url)
-  $('#addNewContact').modal('show')
-}
-$(function() {
-});
-</script>
 {% endblock content %}

--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -8,7 +8,6 @@
 {% block extrajs %}
 $(function() {
   $('.toggle-enable').change(function() {
-
     $.ajax({
       url: "{% url 'toggle-enabled' %}",
       method: 'POST',
@@ -29,9 +28,7 @@ $(function() {
 {% endblock extrascripts %}
 
 {% block header %}
-
 {% include 'nuntium/profiles/per_instance_top_menu.html' with section='contacts-per-writeitinstance' %}
-
 {% endblock header %}
 
 {% block content %}
@@ -41,9 +38,9 @@ $(function() {
   </div>
   <div class="manager-overview">
     {% blocktrans count person_count=writeitinstance.persons.count %}
-    There is <strong>1</strong> recipient in your WriteIt
+    There is <strong>1</strong> Person linked from PopIt
     {% plural %}
-    There are <strong>{{ person_count }}</strong> recipients in your WriteIt
+    There are <strong>{{ person_count }}</strong> People linked from PopIt
     {% endblocktrans %}
   </div>
       {% autopaginate people %}
@@ -62,7 +59,7 @@ $(function() {
             <td>{% show_contacts_for person writeitinstance %}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="3" class="text-center">{% trans "There are no recipients, connect to a data source to add some" %}</td></tr>
+          <tr><td colspan="3" class="text-center">{% trans "There are no People linked from Popit, connect to a data source to add some" %}</td></tr>
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
The recipient manager still refers to “in your WriteIt”. Clean that up (for #530), remove an obsolete modal from when we could manually add contacts, and link to the Data Sources page when we mention it:

Before:
![1 recipient before 2015-04-15 at 08 41 56](https://cloud.githubusercontent.com/assets/57483/7154206/72908f1c-e34b-11e4-9fb5-011504d375be.png)
![many recipients before 2015-04-15 at 08 41 51](https://cloud.githubusercontent.com/assets/57483/7154207/7296ef7e-e34b-11e4-8fb4-c617a760717e.png)
![0 recipients before 2015-04-15 at 08 41 46](https://cloud.githubusercontent.com/assets/57483/7154208/729abc4e-e34b-11e4-8ee4-48b1abd5c789.png)

After:
![1 recipient after 2015-04-15 at 08 41 12](https://cloud.githubusercontent.com/assets/57483/7154209/72a33f36-e34b-11e4-95af-79688c61e4ce.png)
![many recipients after 2015-04-15 at 08 41 06](https://cloud.githubusercontent.com/assets/57483/7154210/72a92da6-e34b-11e4-83d9-23b27746bd4c.png)
![0 recipients after 2015-04-15 at 08 32 34](https://cloud.githubusercontent.com/assets/57483/7154218/7c795d92-e34b-11e4-9c85-291469ed9071.png)





<!---
@huboard:{"order":708.5350785570918,"milestone_order":959,"custom_state":""}
-->
