### PR TITLE
Move moderation to the message admin

### DIFF
--- a/nuntium/templates/nuntium/profiles/message_detail.html
+++ b/nuntium/templates/nuntium/profiles/message_detail.html
@@ -27,14 +27,19 @@
           </dd>
 	  <dt>{% trans "Confirmed" %}</dt>
 	  <dd><i class="fa {% if message.confirmated %}fa-check{% else %}fa-times{% endif %}"></i></dd>
+
 	  {% if message.writeitinstance.config.moderation_needed_in_all_messages %}
 	  	<dt>{% trans "Moderated" %}</dt>
-        <dd><i class="fa {% if message.moderated %}fa-check{% else %}fa-times{% endif %}"></i></dd>
-      {% endif %}
-      {% if message.public %}
-	  <dt>{% trans "Public" %}</dt>
-	  <dd><i class="fa {% if message.public %}fa-check{% else %}fa-times{% endif %}"></i></dd>
-      {% endif %}
+        {% if message.moderated %}
+          <dd><i class="fa fa-check"></i></dd>
+        {% else %}
+          <dd class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated — click here to accept it' %}">
+             <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Accept"%}</button>
+             </form>
+          </dd>
+        {% endif %}
+    {% endif %}
+
 	  {% if message.public %}
 	  <dt>{% trans "Link" %}</dt>
 	  <dd><a href="{% url 'thread_read' slug=message.slug subdomain=message.writeitinstance.slug %}"><i class="fa fa-link"></i> {% trans "Public page" %}</a></dd>
@@ -95,4 +100,10 @@
   </div>
 </div>
 
+<script type="text/javascript">
+$('.explanation').tooltip({})
+</script>
+
 {% endblock content %}
+
+

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -101,14 +101,11 @@
             {% if writeitinstance.config.moderation_needed_in_all_messages %}
               {% if message.moderated %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been accepted' %}"><i class="glyphicon glyphicon-ok"></i></div>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has been accepted' %}"><i class="fa fa-check"></i></div>
               </td>
               {% else %}
               <td class="text-center">
-                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated — click here to accept it' %}">
-                    <form action="{% url 'accept_message' pk=message.pk %}" method="post">{% csrf_token %} <button class="btn btn-default btn-sm moderate">{% trans "Accept"%}</button>
-                    </form>
-                </div>
+                <div class="explanation"  data-toggle="tooltip" data-placement="left" title="{% trans 'This message has not yet been moderated' %}"><i class="fa fa-times"></i></div>
               </td>
               {% endif %}
             {% endif %}


### PR DESCRIPTION
Currently moderation happens from the Messages page, rather than the
individual Message page. This is bad, as you want to be able to read
the message before moderating it. So move the button to there.

NB: This has all the same problems as the previous version, but but
it’s a slightly better version of broken here, and helps clean the
Messages Manager up a little bit more for other things we want to do
there.

Old:
![needs moderated list old 2015-04-15 at 10 30 51](https://cloud.githubusercontent.com/assets/57483/7155968/e656506c-e35a-11e4-8b17-d1c598bb3ca7.png)
![needs moderated message old 2015-04-15 at 10 30 59](https://cloud.githubusercontent.com/assets/57483/7155970/e81ec0be-e35a-11e4-9df7-997fdb6a4920.png)

New:
![needs moderated 2015-04-15 at 10 21 07](https://cloud.githubusercontent.com/assets/57483/7155975/f10c5ccc-e35a-11e4-9569-03670b6c1693.png)

![accept it 2015-04-15 at 10 23 27](https://cloud.githubusercontent.com/assets/57483/7155974/f0f90d16-e35a-11e4-97d3-0b2ba1ce6d40.png)

![now moderated list 2015-04-15 at 10 23 37](https://cloud.githubusercontent.com/assets/57483/7155973/f0f0ded4-e35a-11e4-81fa-1454cfb2d694.png)

![now moderated message 2015-04-15 at 10 24 46](https://cloud.githubusercontent.com/assets/57483/7155976/f1153ad6-e35a-11e4-9acb-6ff9fc702846.png)

Closes #904 

<!---
@huboard:{"order":0.06796470436529489,"milestone_order":965,"custom_state":""}
-->
