### PR TITLE
968 no contactable contacts

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -86,7 +86,7 @@
             <h3 class="site-alert__heading">{% trans "This site is read-only." %}</h3>
             <p class="site-alert__description">{% trans "You can’t currently create new messages using this site." %}</p>
           {% if user.is_authenticated %}
-            <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Change this in Settings" %}</a>
+            <a class="site-alert__cta" href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">{% trans "Change this in Settings" %}</a>
           {% endif %}
         </div>
     </div>
@@ -96,7 +96,7 @@
             <h3 class="site-alert__heading">{% trans "This site has no recipients." %}</h3>
             <p class="site-alert__description">{% trans "There is no-one to write to yet. Please check back soon." %}</p>
           {% if user.is_authenticated %}
-            <a class="site-alert__cta" href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "Import people from PopIt" %}</a>
+            <a class="site-alert__cta" href="{% url 'relate-writeit-popit' subdomain=writeitinstance.slug %}">{% trans "Import people from PopIt" %}</a>
           {% endif %}
         </div>
     </div>

--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -90,7 +90,7 @@
           {% endif %}
         </div>
     </div>
-  {% elif writeitinstance and not writeitinstance.persons.exists %}
+  {% elif writeitinstance and not writeitinstance.persons_with_contacts %}
     <div class="site-alert">
         <div class="container">
             <h3 class="site-alert__heading">{% trans "This site has no recipients." %}</h3>


### PR DESCRIPTION
If you have contacts in your instance, but none of them have email addresses, show the "No contacts" banner, as it'll get people closer to diagnosing the problem. (I still want to investigate what happens when you have _disabled_ all the contacts, but that's for another change #972 and much less likely to happen than someone connecting a PopIt with no emails). Closes #968 

Also, change the links in these banners to go directly to the relevant settings page, rather than the central admin page. Closes #966 

Before: (different URLs in bottom left corner when hovering on links)

![read only before 2015-04-15 at 11 41 26](https://cloud.githubusercontent.com/assets/57483/7157122/7583013c-e364-11e4-812c-1e77c60c9c96.png)
![no recipients before 2015-04-15 at 11 41 13](https://cloud.githubusercontent.com/assets/57483/7157123/758a861e-e364-11e4-8392-2bc434567528.png)


After:
![read only banner 2015-04-15 at 11 36 28](https://cloud.githubusercontent.com/assets/57483/7157096/4588ecee-e364-11e4-9d37-f4f80c9d6833.png)

![no recipients banner 2015-04-15 at 11 36 43](https://cloud.githubusercontent.com/assets/57483/7157095/457ecc6e-e364-11e4-8448-667fc3ee016a.png)



<!---
@huboard:{"order":0.016991176091323723}
-->
