### PR TITLE
Show if a site is already disabled

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -70,7 +70,8 @@
       <hr />
       <div class="page-header">
         <h2>{% trans "Test Sites" %}</h2>
-        <p>
+        <p>{% trans "Sites are set to Testing Mode by default. Use the menu on the left to make sure that your site is set up in the way that you want it. When you are ready, contact us to let us know and we’ll put your site live." %}</p>
+        
             {% blocktrans count counter=test_sites.count %}
                 This site is in Test Mode:
             {% plural %}

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -49,7 +49,13 @@
             <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
             <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
-            <td><a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a></td>
+            <td>
+              {% if writeitinstance.config.allow_messages_using_form %}
+                <a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a>
+              {% else %}
+                <a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">DISABLED</a>
+              {% endif %}
+            </td>
           </tr>
           {% empty %}
           <tr><td colspan="3" class="text-center">You have no sites</td></tr>


### PR DESCRIPTION
In the instance manager, check if an instance is already Disabled before offering a link to disable it.

Before
![disable before 2015-04-15 at 11 50 01](https://cloud.githubusercontent.com/assets/57483/7157376/23d69a94-e367-11e4-9a1e-f900e5e9509a.png)

After
![disable after 2015-04-15 at 12 00 54](https://cloud.githubusercontent.com/assets/57483/7157375/23cf3830-e367-11e4-9c23-7fabe8f5835d.png)

It's a little ugly, but we haven't really solved the "show binary option with ability to change it" problem, so in the absence of design time, this'll have to do for now, especially as it should hopefully be a very rare occurrence.

Fixes #969

Also add new text from @MyfanwyNixon explaining the Test Mode section:

![test mode explanation 2015-04-15 at 12 05 10](https://cloud.githubusercontent.com/assets/57483/7157485/f7e627be-e367-11e4-9cc2-4dad1abb6691.png)



<!---
@huboard:{"order":0.025486764136985585}
-->
