### PR TITLE
Pass ?next parameter through to python-social-auth

### DIFF
--- a/nuntium/templates/registration/login.html
+++ b/nuntium/templates/registration/login.html
@@ -10,7 +10,7 @@
         <p>If you've got an account sign in with it here. If not, it's quick and easy to <a href="#">sign up</a></p>
         <hr />
         <p>{% trans 'You can also&hellip;' %}</p>
-        <a class="btn btn-primary btn-full-width btn-google" href="{% url 'social:begin' 'google-oauth2' %}">
+        <a class="btn btn-primary btn-full-width btn-google" href="{% url 'social:begin' 'google-oauth2' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}">
             <i class="fa fa-google"></i> Sign in with Google
         </a>
     </div>

--- a/nuntium/templates/registration/signup.html
+++ b/nuntium/templates/registration/signup.html
@@ -10,7 +10,7 @@
         <p>If you've got an account sign in with it here. If not, it's quick and easy to <a href="#">sign up</a></p>
         <hr />
         <p>{% trans 'You can also&hellip;' %}</p>
-        <a class="btn btn-primary btn-full-width btn-google" href="{% url 'social:begin' 'google-oauth2' %}">
+        <a class="btn btn-primary btn-full-width btn-google" href="{% url 'social:begin' 'google-oauth2' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}">
             <i class="fa fa-google"></i> Sign in with Google
         </a>
     </div>


### PR DESCRIPTION
This means that if you arrive at the login page from another page, e.g. the create new instance page, then you will get redirected back to that page after signing up/in with Google.

Fixes #963 

<!---
@huboard:{"order":0.008495588045661862,"milestone_order":977,"custom_state":""}
-->
