### PR TITLE
908 check import status

### DIFF
--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -2,11 +2,33 @@
 {% load subdomainurls %}
 {% load staticfiles %}
   <ul class="navigation__list">
-    <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">{% trans "About your site" %}</a></li>
-    <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' subdomain=writeitinstance.slug %}">{% trans "Templates" %}</a></li>
-    <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}">{% trans "Recipients" %}</a></li>
-    <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}">{% trans "Messages" %}</a></li>
-    <li class="{% if section == 'relate-writeit-popit' %}active{% endif %}"><a href="{% url 'relate-writeit-popit' subdomain=writeitinstance.slug %}">{% trans "Data sources" %}</a></li>
-    <li class="{% if section == 'writeitinstance_api_docs' %}active{% endif %}"><a href="{% url 'writeitinstance_api_docs' subdomain=writeitinstance.slug %}">{% trans "API" %}</a></li>
-    <li class="{% if section == 'stats' %}active{% endif %}"><a href="{% url 'stats' subdomain=writeitinstance.slug %}">{% trans "Stats" %}</a></li>
+    <li class="{% if section == 'writeitinstance_basic_update' %}active{% endif %}"><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-info-circle"></i> 
+      {% trans "About your site" %}
+    </a></li>
+    <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-user"></i> 
+      {% trans "Recipients" %}
+    </a></li>
+    
+    <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-envelope-o"></i> 
+      {% trans "Messages" %}
+    </a></li>
+    <li class="{% if section == 'relate-writeit-popit' %}active{% endif %}"><a href="{% url 'relate-writeit-popit' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-database"></i> 
+      {% trans "Data sources" %}
+    </a></li>
+    <li class="{% if section == 'writeitinstance_template_update' %}active{% endif %}"><a href="{% url 'writeitinstance_template_update' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-file"></i> 
+      {% trans "Templates" %}
+    </a></li>
+    <li class="{% if section == 'writeitinstance_api_docs' %}active{% endif %}"><a href="{% url 'writeitinstance_api_docs' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-plug"></i> 
+      {% trans "API" %}
+    </a></li>
+    <li class="{% if section == 'stats' %}active{% endif %}"><a href="{% url 'stats' subdomain=writeitinstance.slug %}">
+      <i class="fa fa-area-chart"></i> 
+      {% trans "Stats" %}
+    </a></li>
   </ul>

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -9,11 +9,13 @@
     <li class="{% if section == 'contacts-per-writeitinstance' %}active{% endif %}"><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}">
       <i class="fa fa-user"></i> 
       {% trans "Recipients" %}
+      <span class="badge">{{ writeitinstance.persons.count }}</span>
     </a></li>
     
     <li class="{% if section == 'messages_per_writeitinstance' %}active{% endif %}"><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}">
       <i class="fa fa-envelope-o"></i> 
       {% trans "Messages" %}
+      <span class="badge">{{ writeitinstance.message_set.count }}</span>
     </a></li>
     <li class="{% if section == 'relate-writeit-popit' %}active{% endif %}"><a href="{% url 'relate-writeit-popit' subdomain=writeitinstance.slug %}">
       <i class="fa fa-database"></i> 

--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -20,9 +20,7 @@
     <div class="page-header">
         <h2>
           {% trans "About your site" %}
-          {% if writeitinstance.pulling_from_popit_status.inprogress > 0 %}
-            <i class="fa fa-spinner fa-pulse" data-toggle="tooltip" data-placement="right" title="{% trans 'We are currently fetching data from PopIt' %}"></i>
-          {% endif %}
+          <span class="import_spinner"></span>
         </h2>
     </div>
 
@@ -43,12 +41,26 @@
       {% csrf_token %}
     </form>
 
-
-<script type="text/javascript">
-  $(function () {
-    $('[data-toggle="tooltip"]').tooltip()
-  })
-</script>
-    
-
 {% endblock content %}
+
+{% block extrajs %}
+
+  var spin_if_pulling = function(url) {
+    var spinning = '<i class="fa fa-spinner fa-pulse" data-toggle="tooltip" data-placement="right" title="{% trans 'We are currently fetching data from PopIt' %}"></i>';
+    $.get(url, function(status){
+      if (status.inprogress >= 1){
+        $(".import_spinner").html(spinning);
+        $('[data-toggle="tooltip"]').tooltip()
+        setTimeout( spin_if_pulling, 2000, url)
+      } else {
+        $(".import_spinner").text("");
+      }
+    })
+  };
+
+  $(function(){
+    spin_if_pulling("{% url 'pulling_status' subdomain=writeitinstance.slug %}");
+  });
+
+{% endblock %}
+

--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -45,21 +45,26 @@
 
 {% block extrajs %}
 
-  var spin_if_pulling = function(url) {
+  var spin_if_pulling = function(url, reload) {
     var spinning = '<i class="fa fa-spinner fa-pulse" data-toggle="tooltip" data-placement="right" title="{% trans 'We are currently fetching data from PopIt' %}"></i>';
     $.get(url, function(status){
       if (status.inprogress >= 1){
         $(".import_spinner").html(spinning);
         $('[data-toggle="tooltip"]').tooltip()
-        setTimeout( spin_if_pulling, 2000, url)
+        setTimeout( spin_if_pulling, 2000, url, 1)
       } else {
         $(".import_spinner").text("");
+        // Ideally we could update the sidebar here, but until we can
+        // find out how many users we *now* have, just reload
+        if (reload == 1) {
+          location.reload() 
+        }
       }
     })
   };
 
   $(function(){
-    spin_if_pulling("{% url 'pulling_status' subdomain=writeitinstance.slug %}");
+    spin_if_pulling("{% url 'pulling_status' subdomain=writeitinstance.slug %}", 0);
   });
 
 {% endblock %}


### PR DESCRIPTION
Make it obvious when a PopIt import finishes. 

If you’re on the Admin page for an instance, it shows a spinner if we’re currently fetching data for that instance. But, confusingly, nothing lets you know when that finishes, so you can sit for ages waiting for it to do something.

So have it only spin when the import is still in progress, and then also update the number of users in the sidebar.

(Which requires actually *adding* the number of users to the sidebar (closes #979); and whilst we’re there adding little icons beside each entry. Scope-creep-orama. The dependency management to do these all as separate changes at this point, especially with the afternoon Huboard delay) isn’t worth it.

![about your site 0 2015-04-15 at 15 45 07](https://cloud.githubusercontent.com/assets/57483/7161685/41ea6f6c-e388-11e4-8333-a2eae129afb4.png)

when finished, automatically becomes:

![about your site 432 2015-04-15 at 15 51 52](https://cloud.githubusercontent.com/assets/57483/7161686/41ed9bc4-e388-11e4-83d8-b0312272cb15.png)

Closes #908 . We might end up needing to do something similar on the Welcome To Your New site page, that has been added since this ticket was raised, but that depends on what that site is/does, as it doesn't really exist yet. #922

<!---
@huboard:{"order":0.03185845517123198,"milestone_order":985,"custom_state":""}
-->
