### PR TITLE
About page

### DIFF
--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -7,6 +7,7 @@ from contactos.views import ToggleContactEnabledView
 from mailit.views import MailitTemplateUpdateView
 from nuntium.models import AnswerAttachment
 from nuntium.views import (
+    AboutView,
     ConfirmView,
     HelpView,
     MessageThreadView,
@@ -115,4 +116,5 @@ urlpatterns = i18n_patterns('',
 
     url(r'^help/(?P<section_name>\w+)/?$', HelpView.as_view(), name='help_section'),
     url(r'^help/?$', HelpView.as_view()),
+    url(r'^about/?$', AboutView.as_view()),
 )

--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -114,7 +114,8 @@ urlpatterns = i18n_patterns('',
     url(r'^manage/', include(managepatterns)),
     url(r'^accounts/logout/$', 'django.contrib.auth.views.logout', kwargs={'next_page': '/'}, name='logout'),
 
+    url(r'^about/?$', AboutView.as_view(), name='about'),
+
     url(r'^help/(?P<section_name>\w+)/?$', HelpView.as_view(), name='help_section'),
     url(r'^help/?$', HelpView.as_view()),
-    url(r'^about/?$', AboutView.as_view()),
 )

--- a/nuntium/templates/about.html
+++ b/nuntium/templates/about.html
@@ -1,0 +1,10 @@
+{% extends "base_instance.html" %}
+{% load i18n %}
+{% load subdomainurls %}
+
+{% block content_inner %}
+<h1>About</h1>
+{% endblock content_inner %}
+~
+
+

--- a/nuntium/templates/about.html
+++ b/nuntium/templates/about.html
@@ -1,9 +1,83 @@
 {% extends "base_instance.html" %}
 {% load i18n %}
-{% load subdomainurls %}
 
 {% block content_inner %}
-<h1>About</h1>
+
+<h2>About This Site</h2>
+
+<p>Got a question for a politician? Want to hold someone to account, get
+answers, or just make a point?</p>
+
+<p>We believe that when conversations are held in public, great things
+happen:</p>
+
+<ul>
+  <li>It’s easier to hold people in power to their word.</li>
+  <li>There’s a permanent record of everything that’s been said.</li>
+  <li>You can share the correspondence with anyone, at any time.</li>
+  <li>And all the while, you’re helping to build a public archive of
+  conversations about the things that matter.</li>
+</ul>
+
+<p>That’s why we built {{ writeitinstance.name }}. </p>
+
+{% comment "needs #914" %}
+With just a few clicks, you can
+now send messages to any member of [name of database]. </p>
+{% endcomment %}
+
+<h3>How does it work?</h3>
+
+<p>Pick your 
+recipient{% if writeitinstance.config.maximum_recipients > 1 %}s{% endif %},
+compose your letter, and press ‘Send’.</p>
+
+<p>Once you’ve confirmed your email address, we’ll send your message on
+its way, and also publish it on this site for everyone to see.</p>
+
+<p>When you get a reply, we’ll publish that too.</p>
+
+{% comment "needs #263" %}
+Perhaps you’d like to continue the conversation? No problem: just click on ‘reply’, and off
+you go. All in public.</p>
+{% endcomment %}
+
+<h3>How public is ‘public’?</h3>
+
+<p><b>We’ll publish your message, and your name alongside it, on this
+public website.</b> You should be aware that, as a result, your
+message will appear in future searches for your name on search
+engines. Anyone browsing this site will also be able to see it.</p>
+
+<p><b>We encourage the use of real names</b>, although it’s not
+mandatory. Your chosen recipient will be obliged to use his or her real
+name when replying, and we think it’s only right that you extend them
+the same courtesy. If you’re not happy to put your name to a message,
+we’d suggest that you don’t send it.</p>
+
+<p><b>We won’t publish your email address</b>. We ask for it so that we can:</p>
+
+<ul>
+  <li>verify that your message has come from a genuine person, not a
+  spammer or a bot</li>
+  <li>alert you when you receive a reply from your recipient</li>
+  <li>let you know of any issues or problems we may have had sending your
+  message</li>
+  <li>(rarely) send you important information about the site.</li>
+</ul>
+
+{% comment "We don't yet store anywhere who runs a site.." %}
+<h3>Who runs this site?</h3>
+<p>This site is run by [name of organisation] [opportunity to add
+description of their remit if required]</p>
+
+<h3>Who built this site?</h3>
+It runs on the WriteIt software, which was developed by mySociety and Fundación Ciudadano Inteligente as a Poplus Component.
+
+You can run a site like this too. — Link to WriteInPublic
+{% endcomment %}
+
+
 {% endblock content_inner %}
 ~
 

--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -31,6 +31,7 @@
             <div class="site-header__nav" id="navbar" role="navigation">
                 <ul>
                     <li class="site-header__nav__link"><a href="{% url 'instance_detail' subdomain=writeitinstance.slug %}">{% trans "Home" %}</a></li>
+                    <li class="site-header__nav__link"><a href="{% url 'about' subdomain=writeitinstance.slug %}">{% trans "About" %}</a></li>
                   {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
                     <li class="site-header__nav__link"><a href="{% url 'write_message' subdomain=writeitinstance.slug %}">{% trans "Send a message" %}</a></li>
                   {% endif %}

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -298,9 +298,14 @@ class WriteSignView(TemplateView):
         return context
 
 
+class AboutView(WriteItInstanceDetailView):
+    template_name = 'about.html'
+
+
 class HelpView(TemplateView):
     def get_template_names(self):
         if 'section_name' in self.kwargs:
             return ["help/{}.html".format(self.kwargs['section_name'])]
         else:
             return ["help/index.html"]
+


### PR DESCRIPTION
Add the text @MyfanwyNixon wrote for the About page (with chunks of it hidden, pending future features). 

We still need to add the bottom "How you can get a site like this too" section.

After some discussion about the best way to internationalise this, we decided to solve that the first time someone actually wants their own version, as it's more likely that someone will want to change the entire page, rather than translate this paragraph by paragraph.

![about page 2015-04-15 at 17 24 37](https://cloud.githubusercontent.com/assets/57483/7163880/57a3cc70-e394-11e4-8320-8c6b2e042d9a.png)


<!---
@huboard:{"order":0.032920403676939713}
-->
