### PR TITLE
More complex logic for "How many people in your instance"

### DIFF
--- a/nuntium/templates/nuntium/profiles/welcome.html
+++ b/nuntium/templates/nuntium/profiles/welcome.html
@@ -4,11 +4,7 @@
 {% block content %}
 
 <div class="page-header">
-    <h2>
-       {% blocktrans with name=writeitinstance.name %}
-         Welcome! This is {{ name }}
-       {% endblocktrans %}
-    </h2>
+    <h2>{% trans "Welcome" %}</h2>
 </div>
 
 <p>
@@ -27,19 +23,32 @@
   </p>
 {% endif %}
 <p>
-  {% if writeitinstance.persons.count %}
-    {% blocktrans count qty_pers=writeitinstance.persons.count %}
-      You've got only <a href="{{ url_recipients }}">one recipient</a> in your database.
+  {% if writeitinstance.persons_with_contacts.count %}
+    {% blocktrans count contactable_count=writeitinstance.persons_with_contacts.count %}
+      You've got only <a href="{{ url_recipients }}">one contactable recipient</a> in your database.
     {% plural %}
-      You've got <a href="{{ url_recipients }}">{{ qty_pers }} recipients</a> in your database.
+      You've got <a href="{{ url_recipients }}">{{ contactable_count }} contactable recipients</a> in your database.
     {% endblocktrans %}
+    {% trans "That‘s great — now you can test writing to them." %}
+  {% elif writeitinstance.persons.count %}
+     {% blocktrans count all_contacts_count=writeitinstance.persons.count %}
+       We loaded {{ all_contacts_count }} person from your
+       PopIt source — but we couldn‘t detect their email addresss.
+       {% plural %}
+       We've loaded {{ all_contacts_count }} people from your
+       PopIt source — but we couldn‘t detect email addresses for them.
+     {% endblocktrans %}
+     {% blocktrans %}
+       <strong>You need to ensure that your PopIt contains email data,
+         or we won't know how to deliver messages.</strong>
+     {% endblocktrans %}
   {% else %}
     {% blocktrans %}
-      <strong>There are <a href="{{ url_recipients }}">no recipients</a> in your database</strong>
-      &mdash; you need to get some in there before anyone can send any messages!
-      <br>
-      Has your data source got recipients in it? Has it loaded OK?
+    We haven't loaded any data from your PopIt instance yet. Sometimes
+    that takes a few minutes, so try reloading this page after you‘ve
+    read the rest of it.
     {% endblocktrans %}
+
   {% endif %}
 </p>
 <p>


### PR DESCRIPTION
We should be checking whether there are contactable persons, not just any persons. If there aren’t, then we can check if it’s because we haven’t loaded _anyone_ yet, or because we couldn’t find email addresses for people.

![contacts yay 2015-04-15 at 18 09 51](https://cloud.githubusercontent.com/assets/57483/7164950/f3df24f2-e39b-11e4-8d6c-f60e4e0cec4b.png)

![no emails 2015-04-15 at 18 08 53](https://cloud.githubusercontent.com/assets/57483/7164952/f3f1c990-e39b-11e4-89e9-72e774f4b443.png)

![no data 2015-04-15 at 18 09 30](https://cloud.githubusercontent.com/assets/57483/7164951/f3e2a2d0-e39b-11e4-9497-d487dcaee934.png)

Closes #990, but more still to do in #992
