### PR TITLE
Add a "How was this site built?" section

### DIFF
--- a/nuntium/templates/about.html
+++ b/nuntium/templates/about.html
@@ -19,11 +19,12 @@ happen:</p>
   conversations about the things that matter.</li>
 </ul>
 
-<p>That’s why we built {{ writeitinstance.name }}. </p>
+<p>That’s why we built {{ writeitinstance.name }}. With just a few clicks 
+you can now send messages to the politicians who represent you.</p>
 
 {% comment "needs #914" %}
-With just a few clicks, you can
-now send messages to any member of [name of database]. </p>
+With just a few clicks, you can now send messages to any member of 
+[name of organisation the recipients are in]. </p>
 {% endcomment %}
 
 <h3>How does it work?</h3>
@@ -70,12 +71,19 @@ we’d suggest that you don’t send it.</p>
 <h3>Who runs this site?</h3>
 <p>This site is run by [name of organisation] [opportunity to add
 description of their remit if required]</p>
-
-<h3>Who built this site?</h3>
-It runs on the WriteIt software, which was developed by mySociety and Fundación Ciudadano Inteligente as a Poplus Component.
-
-You can run a site like this too. — Link to WriteInPublic
 {% endcomment %}
+
+<h3>How was this site built?</h3>
+
+It runs on the WriteInPublic software, which was developed by 
+<a href="http://ciudadanointeligente.org/">Fundación Ciudadano Inteligente</a> and
+<a href="https://www.mysociety.org/ ">mySociety</a> on top of WriteIt, a
+<a href="http://poplus.org/">Poplus</a> Component.
+
+You can run a site like this too. Find out more at 
+<a href="http://WriteInPublic.com">WriteInPublic.com</a>.
+
+<p></p>
 
 
 {% endblock content_inner %}


### PR DESCRIPTION
Add a section to the About page linking to WriteInPublic so people can
have their own instance (and adding some credits). Closes #999 and fixes #740.

![how built 2015-04-15 at 21 00 08](https://cloud.githubusercontent.com/assets/57483/7168130/05682626-e3b3-11e4-9930-a0672b9c5bb9.png)
