### PR TITLE
Don't double flash messages

### DIFF
--- a/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
+++ b/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
@@ -10,25 +10,16 @@
 <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
 <script src="http://malsup.github.com/jquery.form.js"></script> 
 {% endblock extrascripts %}
+
 {% block extrajs %}
 $(".chosen-person-select").chosen();
 {% endblock extrajs %}
 
 {% block header %}
-
 {% include 'nuntium/profiles/per_instance_top_menu.html' with section='relate-writeit-popit' %}
-
 {% endblock header %}
 
 {% block content %}
-
-{% if messages %}
-  <div class="alert alert-info" role="alert">
-    {% for message in messages %}
-    <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
-    {% endfor %}
-  </div>
-{% endif %}
 
   <div class="page-header">
     <h2>{% trans "Data Sources" %}</h2>

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -9,14 +9,6 @@
 
 {% block content %}
 
-{% if messages %}
-  <div class="alert alert-info" role="alert">
-    {% for message in messages %}
-    <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
-    {% endfor %}
-  </div>
-{% endif %}
-
       <div class="page-header">
         <h2>{% trans "Live Sites" %}</h2>
       </div>


### PR DESCRIPTION
The admin section base template already shows all the alert messages —
there’s no need to repeat them within the individual pages as well.

before:
![data sources three flashes 2015-04-15 at 11 04 15](https://cloud.githubusercontent.com/assets/57483/7156525/33238c44-e35f-11e4-8c64-155875624db1.png)

after:
![no inplace message 2015-04-15 at 21 20 51](https://cloud.githubusercontent.com/assets/57483/7168458/7c2a3d56-e3b5-11e4-887b-a80e4d357025.png)

Helps with #967 