### PR TITLE
Remove the "We are now getting the people from popit" message

### DIFF
--- a/nuntium/user_section/tests/popit_instance_update_tests.py
+++ b/nuntium/user_section/tests/popit_instance_update_tests.py
@@ -187,19 +187,6 @@ class RelateMyWriteItInstanceWithAPopitInstance(UserSectionTestCase):
         self.assertTrue(messages)
         self.assertEquals(messages[0].message, _('We could not connect with the URL'))
 
-    def test_insights_about_pulling_popit_even_if_everything_goes_ok(self):
-        '''Return some insights even if everything goes ok'''
-        self.client.login(username="fieraferoz", password="feroz")
-        url = reverse('relate-writeit-popit', subdomain=self.writeitinstance.slug)
-        data = self.data
-        response = self.client.post(url, data=data)
-        expected_follow_url = reverse('relate-writeit-popit', subdomain=self.writeitinstance.slug)
-        self.assertRedirects(response, expected_follow_url)
-        response = self.client.get(expected_follow_url)
-        messages = list(response.context['messages'])
-        self.assertTrue(messages)
-        self.assertEquals(messages[0].message, _("We are now getting the people from popit"))
-
     def test_get_the_url(self):
         form = RelatePopitInstanceWithWriteItInstance(data=self.data, writeitinstance=self.writeitinstance)
         form.is_valid()

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -486,7 +486,6 @@ class WriteitPopitRelatingView(FormView):
         form.relate()
         # It returns an AsyncResult http://celery.readthedocs.org/en/latest/reference/celery.result.html
         # that we could use for future information about this process
-        view_messages.add_message(self.request, view_messages.INFO, _("We are now getting the people from popit"))
         return super(WriteitPopitRelatingView, self).form_valid(form)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
We don’t need to give a separate flash message about getting people, as
we already have the one that says that we’re actively pulling people.

![single flash 2015-04-15 at 21 27 33](https://cloud.githubusercontent.com/assets/57483/7168579/57f4461a-e3b6-11e4-803c-a37dd47b7c00.png)


Closes #967 (in conjunction with #1001)