### PR TITLE
Add web_api_settings context processor

### DIFF
--- a/writeit/context_processors.py
+++ b/writeit/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def web_api_settings(request):
+    return {'WEB_BASED': settings.WEB_BASED, 'API_BASED': settings.API_BASED}

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -152,6 +152,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.contrib.messages.context_processors.messages",
     'social.apps.django_app.context_processors.backends',
     'social.apps.django_app.context_processors.login_redirect',
+    'writeit.context_processors.web_api_settings',
     )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
This exposes `WEB_BASED` and `API_BASED` settings to the template so you
can do something like:

    {% if WEB_BASED %}
    Something
    {% endif %}

in the templates.