### PR TITLE
Link to the Welcome Page from Status Bar

### DIFF
--- a/nuntium/templates/nuntium/profiles/status-bar.html
+++ b/nuntium/templates/nuntium/profiles/status-bar.html
@@ -1,12 +1,12 @@
 {% load i18n %}
-{% load subdomainurls %}
 {% load staticfiles %}
 
 {% if writeitinstance.config.testing_mode %}
   <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle"></i> 
+      {% url 'welcome' as welcome_page %}
       {% blocktrans %}
-        This instance is in testing mode. 
+        This site is in <a href="{{ welcome_page }}">testing mode.</a>
         All mails will be sent to you, rather than the representatives.
         Contact us when you're ready to go live!
       {% endblocktrans %}


### PR DESCRIPTION
When we talk about “testing mode” link to the Welcome Page, which will
explain it again.

![testing mode header 2015-04-15 at 22 48 37](https://cloud.githubusercontent.com/assets/57483/7170024/80028ad4-e3c2-11e4-9c20-c39918c8633f.png)
