### PR TITLE
Don't validate slug if none provided

### DIFF
--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -160,6 +160,8 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
 
     def clean_slug(self):
         slug = self.cleaned_data['slug']
+        if not slug:
+            return slug
         url_validator = validators.URLValidator(message="Enter a valid subdomain")
         url = 'http://%s.example.com' % slug
         url_validator(url)


### PR DESCRIPTION
If the user doesn't supply a slug in the site creation process then don't try and validate it and let the ORM automatically choose one.

This was originally supposed to be part of https://github.com/ciudadanointeligente/write-it/pull/988, but got lost when adding validations for the format of the subdomain.