### PR TITLE
Switch the header and `title` between WriteInPublic and WriteIt

### DIFF
--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -14,7 +14,11 @@
     <meta name="author" content="">
     <link rel="shortcut icon" href="../../docs-assets/ico/favicon.png">
     <link href='http://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    {% if WEB_BASED %}
+    <title>{{ writeitinstance|default:'WriteInPublic' }}</title>
+    {% else %}
     <title>{{ writeitinstance|default:'WriteIt' }}</title>
+    {% endif %}
 
     <!-- Latest compiled and minified JavaScript -->
     <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
@@ -45,6 +49,8 @@
             <a class="navbar-brand" href="/">
             {% if writeitinstance.name %}
               {{ writeitinstance.name }}
+            {% elif WEB_BASED %}
+              Write In Public
             {% else %}
               WriteIt
             {% endif %}


### PR DESCRIPTION
Set the HTML `title`, and the title in the header to either
WriteInPublic or WriteIt based on the settings.

With `API_BASED = True`:

![write it 2015-04-15 at 23 19 21](https://cloud.githubusercontent.com/assets/57483/7170486/6f0c7ca4-e3c6-11e4-9a4c-7ba6a5ca79bd.png)

With `WEB_BASED = True`:

![write in public 2015-04-15 at 23 18 54](https://cloud.githubusercontent.com/assets/57483/7170487/6f11d992-e3c6-11e4-94b5-a6b79f4a7231.png)



Finally closes #530 (hopefully)
