### PR TITLE
Different Web vs API admin pages

### DIFF
--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -34,7 +34,10 @@ $(function() {
 {% block content %}
   <div class="page-header">
     <h2>{% trans "Recipients" %}</h2>
-    <a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}" class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i> {% trans "Settings" %}</a>
+    {% if WEB_BASED %}
+      <a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}" 
+        class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i> {% trans "Settings" %}</a>
+    {% endif %}
   </div>
   <div class="manager-overview">
     {% blocktrans count person_count=writeitinstance.persons.count %}

--- a/nuntium/templates/nuntium/profiles/manager-navigation.html
+++ b/nuntium/templates/nuntium/profiles/manager-navigation.html
@@ -25,10 +25,12 @@
       <i class="fa fa-file"></i> 
       {% trans "Templates" %}
     </a></li>
+  {% if API_BASED %}
     <li class="{% if section == 'writeitinstance_api_docs' %}active{% endif %}"><a href="{% url 'writeitinstance_api_docs' subdomain=writeitinstance.slug %}">
       <i class="fa fa-plug"></i> 
       {% trans "API" %}
     </a></li>
+  {% endif %}
     <li class="{% if section == 'stats' %}active{% endif %}"><a href="{% url 'stats' subdomain=writeitinstance.slug %}">
       <i class="fa fa-area-chart"></i> 
       {% trans "Stats" %}

--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -21,7 +21,9 @@
             <th>{% trans 'Recipients' %}</th>
             <th>{% trans 'Messages' %}</th>
             <th>{% trans 'Edit' %}</th>
+          {% if WEB_BASED %}
             <th>{% trans 'Disable' %}</th>
+          {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -41,6 +43,7 @@
             <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
             <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
+          {% if WEB_BASED %}
             <td>
               {% if writeitinstance.config.allow_messages_using_form %}
                 <a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a>
@@ -48,6 +51,7 @@
                 <a href="{% url 'writeitinstance_webbased_update' subdomain=writeitinstance.slug %}">DISABLED</a>
               {% endif %}
             </td>
+          {% endif %}
           </tr>
           {% empty %}
           <tr><td colspan="3" class="text-center">You have no sites</td></tr>


### PR DESCRIPTION
Show different admin pages depending on whether we’re API_BASED or WEB_BASED.

Ideally we’d do this per *instance* rather than per *server*, but that depends on #998, so this will do for now (especially as the pages all still exist in either case, it’s just that the links to them will be hidden).

About :

API_BASED (API link):
![api about 2015-04-16 at 01 36 12](https://cloud.githubusercontent.com/assets/57483/7172134/6ddf5b76-e3da-11e4-9926-50166eb5eee6.png)

WEB_BASED (no API link):
![web about 2015-04-16 at 01 39 05](https://cloud.githubusercontent.com/assets/57483/7172131/65efecb4-e3da-11e4-9be0-ad9c6c5c3e41.png)

Recipients Manager:
API_BASED:
![api recipients 2015-04-16 at 01 36 20](https://cloud.githubusercontent.com/assets/57483/7172133/6dc3de00-e3da-11e4-97ed-c16393ebeab7.png)

WEB_BASED:
![web recipients 2015-04-16 at 01 38 54](https://cloud.githubusercontent.com/assets/57483/7172132/65f5f528-e3da-11e4-89f1-d34bf1b06f08.png)

Sites Manager:
API_BASED:
![api sites 2015-04-16 at 01 35 58](https://cloud.githubusercontent.com/assets/57483/7172135/6de903ec-e3da-11e4-9862-4ee7d0094cca.png)

WEB_BASED:
![web sites 2015-04-16 at 01 39 45](https://cloud.githubusercontent.com/assets/57483/7172130/65e87a74-e3da-11e4-8142-ebd6524627a4.png)

Closes #996 