### PR TITLE
Go to site admin from public header

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -57,13 +57,17 @@
                             <li class="divider"></li>
                             <li>
                                 <a href="{% url 'account' subdomain=None %}">
-                                    <span class="glyphicon glyphicon-cog"></span>
+                                    <span class="glyphicon glyphicon-user"></span>
                                     {% trans "Your Profile" %}
                                 </a>
                             </li>
                             <li>
-                                <a href="{% url 'your-instances' subdomain=None %}">
-                                    <span class="glyphicon glyphicon-tasks"></span>
+                              {% if writeitinstance.config.testing_mode %}
+                                <a href="{% url 'welcome' subdomain=writeitinstance.slug %}">
+                              {% else %}
+                                <a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">
+                              {% endif %}
+                                    <span class="glyphicon glyphicon-cog"></span>
                                     {% trans "Site Manager" %}
                                 </a>
                             </li>


### PR DESCRIPTION
If logged in as the admin, go directly to that site’s admin from header bar, rather than your Sites Manager.

If it’s still in testing mode, go to the welcome page; otherwise the main edit page.

Closes #1016