### PR TITLE
Show counts for total contacts and contactable people

### DIFF
--- a/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
+++ b/nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html
@@ -37,11 +37,19 @@ $(function() {
     <a href="{% url 'writeitinstance_maxrecipients_update' subdomain=writeitinstance.slug %}" class="page-header__settings-link btn btn-default btn-sm"><i class="glyphicon glyphicon-wrench"></i> {% trans "Settings" %}</a>
   </div>
   <div class="manager-overview">
-    {% blocktrans count person_count=writeitinstance.persons.count %}
-    There is <strong>1</strong> Person linked from PopIt
+
+  {% if writeitinstance.persons.count %}
+    {% blocktrans count person_count=writeitinstance.persons_with_contacts.count %}
+    There is <strong>1</strong> contactable person
     {% plural %}
-    There are <strong>{{ person_count }}</strong> People linked from PopIt
+    There are <strong>{{ person_count }}</strong> contactable people 
     {% endblocktrans %}
+
+    {% if writeitinstance.persons_with_contacts.count < writeitinstance.persons.count %}
+    from <strong>{{ writeitinstance.persons.count }}</strong> total records
+    {% endif %}
+  {% endif %}
+
   </div>
       {% autopaginate people %}
       {% paginate %}


### PR DESCRIPTION
If the number of contactable people is different from the total number of contacts in your database, it’s useful to see both counts.

![riigikogu 2015-04-16 at 07 33 05](https://cloud.githubusercontent.com/assets/57483/7175325/123e872a-e40b-11e4-89b8-c5d467a6343f.png)

![eduskunta 2015-04-16 at 07 32 59](https://cloud.githubusercontent.com/assets/57483/7175326/1243949a-e40b-11e4-9bd6-8cb903764282.png)

![wales 2015-04-16 at 07 32 44](https://cloud.githubusercontent.com/assets/57483/7175327/124ae16e-e40b-11e4-9935-ac452e69f237.png)




Closes #1020