### PR TITLE
Don't link to admin section of other people's sites

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -62,12 +62,17 @@
                                 </a>
                             </li>
                             <li>
+                            {% if user.id == writeitinstance.owner.id %}
                               {% if writeitinstance.config.testing_mode %}
                                 <a href="{% url 'welcome' subdomain=writeitinstance.slug %}">
                               {% else %}
                                 <a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}">
                               {% endif %}
                                     <span class="glyphicon glyphicon-cog"></span>
+                            {% else %}
+                                <a href="{% url 'your-instances' subdomain=None %}">
+                                    <span class="glyphicon glyphicon-tasks"></span>
+                            {% endif %}
                                     {% trans "Site Manager" %}
                                 </a>
                             </li>


### PR DESCRIPTION
In the header bar, if logged in, but viewing someone else’s site, link to your own Sites Manager, instead of that site’s admin.

(It might be nice to see if the person only _has_ one site, and if so link directly to it, but that's overkill for here)

Closes #1022