### PR TITLE
1025 move api key

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-profile.html
+++ b/nuntium/templates/nuntium/profiles/your-profile.html
@@ -46,12 +46,6 @@
           <p class="form-control-static">{{ user.email }}</p>
         </div>
       </div>
-      <div class="form-group">
-        <label class="col-sm-2 control-label">{% trans "Api Key" %}</label>
-        <div class="col-sm-10">
-          <p class="form-control-static">{{ user.api_key.key }}</p>
-        </div>
-      </div>
       {% comment "Hiding these until there's a plan for what can be edited on this page" %}
       <div class="form-group">
         <label for="password" class="col-sm-2 control-label">Password</label>

--- a/nuntium/templates/nuntium/writeitinstance_autoconfirm_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_autoconfirm_form.html
@@ -15,6 +15,10 @@
         <a href="{% url 'writeitinstance_api_docs' subdomain=writeitinstance.slug %}" class=""><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to API" %}</a>
     </div>
 
+    <h4>Your API Key is <tt>{{ user.api_key.key }}</tt></h4>
+
+    <hr />
+
     <form role="form" action="" method="post">
       <div class="settings-group">
         <h3>{% trans 'API Autoconfirm' %}</h3>


### PR DESCRIPTION
Don’t show the API key on the User page — it’ll just confuse most users. Show it on the API Settings page instead for users who _do_ need it, and would naturally look for it there.

before:
![api settings before 2015-04-16 at 08 12 49](https://cloud.githubusercontent.com/assets/57483/7175869/0ff42ae6-e411-11e4-95a4-b2b19a8d353f.png)

after:
![api settings after 2015-04-16 at 08 14 16](https://cloud.githubusercontent.com/assets/57483/7175868/0fd6d75c-e411-11e4-8d25-11d8cb823df7.png)


Closes #1025