### PR TITLE
Show the Admin's name rather than username in the header

### DIFF
--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -62,7 +62,7 @@
               <li{% block menu-login-active %}{% endblock menu-login-active %}><a href="{% url 'login' subdomain=None %}">Sign in</a></li>
               {% else %}
               <li class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i> {{ user }} <b class="caret"></b></a>
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i> {{ user.first_name }} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' subdomain=None %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
                   <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Site Manager" %}</a></li>


### PR DESCRIPTION
Before:
![username 2015-04-16 at 08 26 52](https://cloud.githubusercontent.com/assets/57483/7176007/606928ae-e412-11e4-8401-ba8376d04ce6.png)

After:
![name 2015-04-16 at 08 24 12](https://cloud.githubusercontent.com/assets/57483/7176015/76176a26-e412-11e4-8c7f-1e48efd79fc7.png)



Closes #1024