### PR TITLE
Remove link to non-existent Sign Up page

### DIFF
--- a/nuntium/templates/registration/login.html
+++ b/nuntium/templates/registration/login.html
@@ -7,7 +7,8 @@
 <div class="accounts-box">
     <div class="accounts-box__instructions">
         <h1>{% trans 'Sign in' %}</h1>
-        <p>If you've got an account sign in with it here. If not, it's quick and easy to <a href="#">sign up</a></p>
+        <p>If you've got an account, sign in with it here. If not, you
+        can create one using the “Sign in with Google” button.</p>
         <hr />
         <p>{% trans 'You can also&hellip;' %}</p>
         <a class="btn btn-primary btn-full-width btn-google" href="{% url 'social:begin' 'google-oauth2' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}">


### PR DESCRIPTION
The sign-up page pretends there’s a sign up page. There isn’t (yet #620). Explain that they need to Sign in with Google instead.

Before:
![sign up 2015-04-16 at 07 01 58](https://cloud.githubusercontent.com/assets/57483/7174923/8b15106a-e406-11e4-9e41-ba52cc237d80.png)

After:
![sign up 2015-04-16 at 09 35 03](https://cloud.githubusercontent.com/assets/57483/7177107/f6ce949c-e41b-11e4-8f54-df56b22e1a4b.png)


Closes #1019