### PR TITLE
Don't include message content in new answer notification.

### DIFF
--- a/nuntium/templates/nuntium/mails/new_answer.txt
+++ b/nuntium/templates/nuntium/mails/new_answer.txt
@@ -10,11 +10,6 @@ You can see their response at
 
 {message_url}
 
-
-{person} said:
-
-{content}
-
 -- 
 
 Thanks for using {writeit_name}

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -147,7 +147,9 @@ class NewAnswerNotificationToSubscribers(TestCase):
             'author_name': 'Fiera',
             'person': 'Pedro',
             'subject': 'Subject 1',
-            'content': self.answer_content,
+            # Wer'e not including content here until we can include attachments too
+            # See #930.
+            # 'content': self.answer_content,
             'writeit_name': 'instance 1',
             'message_url_part': 'thread/subject-1',
             }


### PR DESCRIPTION
Until we can include an indication of what attachments there are,
let's not include the message content at all.

This should be done after #1028 

<!---
@huboard:{"order":0.05097352827397117,"milestone_order":1034,"custom_state":""}
-->
