### PR TITLE
Deacivate translation for the new answer email url.

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -2,7 +2,7 @@ import textwrap
 
 from django.db.models.signals import post_save, pre_save
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import override, ugettext_lazy as _
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from popit.models import Person, ApiInstance
 from contactos.models import Contact
@@ -491,7 +491,8 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
         connection = writeitinstance.config.get_mail_connection()
         new_answer_template = writeitinstance.new_answer_notification_template
 
-        message_url = reverse('thread_read', subdomain=writeitinstance.slug, kwargs={'slug': answer.message.slug})
+        with override(None, deactivate=True):
+            message_url = reverse('thread_read', subdomain=writeitinstance.slug, kwargs={'slug': answer.message.slug})
 
         context = {
             'author_name': answer.message.author_name,


### PR DESCRIPTION
The new answer notification email is not sent as a response
to a user request, but rather to an email arriving. Because of this,
we can't set the active language based on the user's browser settings
or cookies, so let's deactivate translation of this url completely.

I'm hoping this will fix #828.

<!---
@huboard:{"order":1040.0,"milestone_order":1036,"custom_state":""}
-->
