### PR TITLE
Fix links and From: address in emails sent to representatives 

### DIFF
--- a/contactos/tests/contacts_tests.py
+++ b/contactos/tests/contacts_tests.py
@@ -16,6 +16,7 @@ from subdomains.utils import reverse
 import simplejson as json
 from nuntium.models import WriteItInstance
 from django.db.models import Q
+from django.contrib.sites.models import Site
 
 
 class ContactTestCase(TestCase):
@@ -269,7 +270,7 @@ class ResendOutboundMessages(TestCase):
 
     def test_resends_only_failed_outbound_messages(self):
         message = Message.objects.get(id=1)
-        OutboundMessage.objects.create(message=message, contact=self.contact, status="ready")
+        OutboundMessage.objects.create(message=message, contact=self.contact, status="ready", site=Site.objects.get_current())
         self.contact.resend_messages()
         current_amount_of_mails_sent_after_resend_messages = len(mail.outbox)
         self.assertEquals(current_amount_of_mails_sent_after_resend_messages - self.previous_amount_of_mails,

--- a/example_data.yaml
+++ b/example_data.yaml
@@ -40,19 +40,19 @@
 - fields: {content: Content 4, subject: Subject 4, confirmated: True, writeitinstance: 2, slug: subject-4, author_name: Fiera, author_email: fiera@ciudadanointeligente.org}
   model: nuntium.message
   pk: 4
-- fields: {contact: 1, message: 1}
+- fields: {contact: 1, message: 1, site: 1}
   model: nuntium.outboundmessage
   pk: 1
-- fields: {contact: 2, message: 1}
+- fields: {contact: 2, message: 1, site: 1}
   model: nuntium.outboundmessage
   pk: 2
-- fields: {contact: 3, message: 1}
+- fields: {contact: 3, message: 1, site: 1}
   model: nuntium.outboundmessage
   pk: 3
-- fields: {contact: 1, message: 2}
+- fields: {contact: 1, message: 2, site: 1}
   model: nuntium.outboundmessage
   pk: 4
-- fields: {contact: 1, message: 4}
+- fields: {contact: 1, message: 4, site: 1}
   model: nuntium.outboundmessage
   pk: 5
 - fields: {url: 'http://popit.org/api/v1'}

--- a/mailit/tests/email_parser/incoming_mail_tests.py
+++ b/mailit/tests/email_parser/incoming_mail_tests.py
@@ -5,6 +5,7 @@ from requests.models import Request
 
 from django.utils.unittest import skip
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 
 from nuntium.models import OutboundMessage, OutboundMessageIdentifier, Message, OutboundMessagePluginRecord, Answer
 from contactos.models import Contact
@@ -324,7 +325,7 @@ class BouncedMailInAmazonBug(TestCase):
         super(BouncedMailInAmazonBug, self).setUp()
         self.message = Message.objects.get(id=1)
         self.contact = Contact.objects.get(value="mailnoexistente@ciudadanointeligente.org")
-        self.outbound_message = OutboundMessage.objects.create(message=self.message, contact=self.contact)
+        self.outbound_message = OutboundMessage.objects.create(message=self.message, contact=self.contact, site=Site.objects.get_current())
         identifier = OutboundMessageIdentifier.objects.get(outbound_message=self.outbound_message)
         identifier.key = "4aaaabbb"
         identifier.save()
@@ -353,7 +354,7 @@ class BouncedMailInGmail(TestCase):
         self.message = Message.objects.get(id=1)
         self.contact = Contact.objects.get(value="mailnoexistente@ciudadanointeligente.org")
         self.outbound_message = OutboundMessage.objects.create(
-            message=self.message, contact=self.contact)
+            message=self.message, contact=self.contact, site=Site.objects.get_current())
         self.outbound_message.send()
         identifier = OutboundMessageIdentifier.objects.get(outbound_message=self.outbound_message)
         identifier.key = "4aaaabbb"
@@ -386,7 +387,7 @@ class EmailReadingExamplesTestCase(TestCase):
         super(EmailReadingExamplesTestCase, self).setUp()
         self.message = Message.objects.get(id=1)
         self.contact = Contact.objects.get(value="falvarez@ciudadanointeligente.cl")
-        self.outbound_message = OutboundMessage.objects.create(message=self.message, contact=self.contact)
+        self.outbound_message = OutboundMessage.objects.create(message=self.message, contact=self.contact, site=Site.objects.get_current())
         self.outbound_message.send()
         identifier = OutboundMessageIdentifier.objects.get(outbound_message=self.outbound_message)
         identifier.key = "7e460e9c462411e38ef81231400178dd"

--- a/nuntium/management/commands/send_mails.py
+++ b/nuntium/management/commands/send_mails.py
@@ -1,4 +1,6 @@
 from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+
 from ...models import OutboundMessage
 import logging
 
@@ -6,7 +8,7 @@ logging.basicConfig(filename='send_mails.log', level=logging.INFO)
 
 
 def send_mails():
-    outbound_messages = OutboundMessage.objects.to_send()
+    outbound_messages = OutboundMessage.objects.to_send().filter(site=Site.objects.get_current())
     logging.info('Sending messages')
     for outbound_message in outbound_messages:
         outbound_message.send()

--- a/nuntium/migrations/0063_add_site_to_outbound_message.py
+++ b/nuntium/migrations/0063_add_site_to_outbound_message.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'OutboundMessage.site'
+        db.add_column(u'nuntium_outboundmessage', 'site',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=1, to=orm['sites.Site']),
+                      keep_default=False)
+
+        # Adding field 'NoContactOM.site'
+        db.add_column(u'nuntium_nocontactom', 'site',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=1, to=orm['sites.Site']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'OutboundMessage.site'
+        db.delete_column(u'nuntium_outboundmessage', 'site_id')
+
+        # Deleting field 'NoContactOM.site'
+        db.delete_column(u'nuntium_nocontactom', 'site_id')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerattachment': {
+            'Meta': {'object_name': 'AnswerAttachment'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 4, 16, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_text': ('django.db.models.fields.TextField', [], {'default': "u'Hello {author_name}\\n\\n\\nYou just submitted a message via {writeit_name}. Please visit the following link to confirm you want to send this message\\n\\n{confirmation_url}\\n\\n(If you can\\u2019t click the link, try copying and pasting it into your browser\\u2019s address bar)\\n\\n**IMPORTANT** Once confirmed and sent, the message will also be published on {writeit_name}, where your name, your message, and any replies, will be public and online for anyone to read, and will also appear in search engine results.\\n\\nIf this message didn\\u2019t come from you (or you\\u2019ve changed your mind and don\\u2019t want to send it after all) please just ignore this email.\\n\\nThanks for using {writeit_name}, and here is a copy of your message for your records:\\n\\n\\nTo: {recipients}\\nSubject: {subject}\\n\\n{content}\\n'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'default': "u'Please confirm your WriteIt message to {recipients}\\n'", 'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 4, 16, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "u'{person} has replied to your message {subject}\\n'", 'max_length': '255'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'template_text': ('django.db.models.fields.TextField', [], {'default': 'u\'Dear {author_name}\\n\\n{person} has replied to your {writeit_name}\\nmessage with subject\\n\\n"{subject}"\\n\\n\\nYou can see their response at\\n\\n{message_url}\\n\\n\\n{person} said:\\n\\n{content}\\n\\n-- \\n\\nThanks for using {writeit_name}\\n\''}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_create_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'maximum_recipients': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'periodicity': ('django.db.models.fields.CharField', [], {'default': "'1W'", 'max_length': "'2'"}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['nuntium']

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -21,6 +21,7 @@ import re
 from django.db.models import Q
 import requests
 from django.utils.timezone import now
+from django.contrib.sites.models import Site
 
 from annoying.fields import AutoOneToOneField
 
@@ -380,7 +381,7 @@ class Message(models.Model):
         for contact in person.contact_set.filter(writeitinstance=self.writeitinstance):
             if not contact.is_bounced:
                 OutboundMessage.objects.get_or_create(
-                    contact=contact, message=self)
+                    contact=contact, message=self, site=Site.objects.get_current())
 
     def save(self, *args, **kwargs):
         created = self.id is None
@@ -574,6 +575,7 @@ class AbstractOutboundMessage(models.Model):
         choices=STATUS_CHOICES,
         default="new",
         )
+    site = models.ForeignKey(Site)
 
     class Meta:
         abstract = True
@@ -608,6 +610,7 @@ def create_new_outbound_messages_for_newly_created_contact(sender, instance, cre
             # here I should test that it also
             # copies the status
             status=no_contact_om.status,
+            site=Site.objects.get_current(),
             )
 
     no_contact_oms.delete()

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -376,7 +376,7 @@ class Message(models.Model):
 
     def create_outbound_messages_to_person(self, person):
         if not person.contact_set.all():
-            NoContactOM.objects.get_or_create(message=self, person=person)
+            NoContactOM.objects.get_or_create(message=self, person=person, site=Site.objects.get_current())
             return
         for contact in person.contact_set.filter(writeitinstance=self.writeitinstance):
             if not contact.is_bounced:


### PR DESCRIPTION
This associates all outbound messages with a `Site` object from the django sites framework. The plan is to then have a separate celery worker for each site which just sends the emails for that specific domain.

- [x] Fix the tests

Fixes #1033 

<!---
@huboard:{"order":0.03823014620547838,"milestone_order":1037,"custom_state":""}
-->
