### PR TITLE
Check for existing slugs case-insensitively

### DIFF
--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -206,7 +206,7 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
         url_validator = validators.URLValidator(message="Enter a valid subdomain")
         url = 'http://%s.example.com' % slug
         url_validator(url)
-        slug_exists = WriteItInstance.objects.filter(slug=slug).exists()
+        slug_exists = WriteItInstance.objects.filter(slug__iexact=slug).exists()
         if slug_exists:
             raise ValidationError(_("This subdomain has already been taken."))
         return slug


### PR DESCRIPTION
When we check if a proposed slug is already taken, make sure not to ignore case, so if 'eduskunta' is already taken, and someone asks for 'eDuSkUnTa', don’t let them proceed.

![case insensitive screen shot 2015-04-16 at 17 49 40](https://cloud.githubusercontent.com/assets/57483/7186397/3c0a214e-e461-11e4-87c8-7c6210da1e6a.png)



Closes #1012