### PR TITLE
Admin-side contact us

### DIFF
--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -25,6 +25,7 @@ from nuntium.user_section.views import (
     AnswerCreateView,
     AnswerUpdateView,
     ConfirmationTemplateUpdateView,
+    ContactUsView,
     MessageDetail,
     MessagesPerWriteItInstance,
     NewAnswerNotificationTemplateUpdateView,
@@ -89,6 +90,7 @@ managepatterns = patterns('',
     url(r'^messages/(?P<pk>[-\d]+)/toggle-public/$', MessageTogglePublic.as_view(), name='toggle_public'),
     url(r'^moderation_accept/(?P<slug>[-\w]+)/?$', AcceptModerationView.as_view(), name='moderation_accept'),
     url(r'^moderation_reject/(?P<slug>[-\w]+)/?$', RejectModerationView.as_view(), name='moderation_rejected'),
+    url(r'^contact/$', ContactUsView.as_view(), name='contact_us'),
     url(r'^welcome/$', WelcomeView.as_view(), name='welcome'),
 
 )

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -66,6 +66,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' subdomain=None %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
                   <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Site Manager" %}</a></li>
+                  <li><a href="{% url 'contact_us' %}"><span class="glyphicon glyphicon-flash"></span> Contact Us</a></li>
                   <li><a href="{% url 'django.contrib.auth.views.logout' %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
                 </ul>
               </li>

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -66,7 +66,6 @@
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'account' subdomain=None %}"><span class="glyphicon glyphicon-cog"></span> {% trans "Your Profile" %}</a></li>
                   <li><a href="{% url 'your-instances' subdomain=None %}"><span class="glyphicon glyphicon-tasks"></span> {% trans "Site Manager" %}</a></li>
-                  <li><a href="{% url 'contact_us' %}"><span class="glyphicon glyphicon-flash"></span> Contact Us</a></li>
                   <li><a href="{% url 'django.contrib.auth.views.logout' %}"><span class="glyphicon glyphicon-log-out"></span> Sign out</a></li>
                 </ul>
               </li>

--- a/nuntium/templates/nuntium/profiles/contact.html
+++ b/nuntium/templates/nuntium/profiles/contact.html
@@ -1,0 +1,26 @@
+{% extends "base_manager.html" %}
+
+{% load i18n %}
+
+{% block content %}
+
+<div class="page-header">
+    <h2>{% trans "Contact Us" %}</h2>
+</div>
+
+{% blocktrans %}
+<p>Need us to take your site out of Test Mode? Want us to fix something 
+about how the site works, or add a feature? Or just want to shower us with
+praise?</p>
+
+<p>We'd love to hear from you — what you like about the site, what you
+hate about it, or what you wish it did differently.</p>
+
+<p>Just email us at <tt>team@writeinpublic.com</tt></p>
+{% endblocktrans %}
+
+
+{% endblock content %}
+~
+
+

--- a/nuntium/templates/nuntium/profiles/status-bar.html
+++ b/nuntium/templates/nuntium/profiles/status-bar.html
@@ -5,10 +5,11 @@
   <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle"></i> 
       {% url 'welcome' as welcome_page %}
+      {% url 'contact_us' as contact_page %}
       {% blocktrans %}
         This site is in <a href="{{ welcome_page }}">testing mode.</a>
         All mails will be sent to you, rather than the representatives.
-        Contact us when you're ready to go live!
+        <a href="{{ contact_page }}">Contact us</a> when you're ready to go live!
       {% endblocktrans %}
   </div>
 {% endif %}

--- a/nuntium/templates/nuntium/profiles/welcome.html
+++ b/nuntium/templates/nuntium/profiles/welcome.html
@@ -18,11 +18,12 @@
 </p>
 {% if writeitinstance.config.testing_mode %}
   <p>
+    {% url 'contact_us' as contact_page %}
     {% blocktrans %}
       You're currently running in <strong>testing mode</strong>, so all
       the emails sent will go to you (and not the recipients).
-      Contact us when you want this restriction lifted and you're ready to
-      send real messages to real people!
+      <a href="{{ contact_page }}">Contact us</a> when you want this 
+      restriction lifted and you're ready to send real messages to real people!
     {% endblocktrans %}
   </p>
 {% endif %}

--- a/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
@@ -1,6 +1,5 @@
 {% extends "base_manager.html" %}
 {% load i18n %}
-{% load subdomainurls %}
 {% load staticfiles %}
 
 
@@ -12,7 +11,7 @@
 
     <div class="page-header">
         <h2>{% trans 'Recipients settings' %}</h2>
-        <a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to recipients" %}</a>
+        <a href="{% url 'contacts-per-writeitinstance' %}"><i class="glyphicon glyphicon-arrow-left"></i> {% trans "back to recipients" %}</a>
     </div>
 
 
@@ -24,11 +23,13 @@
         be sent to.
         {% endblocktrans %}</p>
 
+        {% url 'contact_us' as contact_page %}
         <p class="help-block">{% blocktrans %}
         This is limited to a maximum of ten recipients per message. If you
         want to enable sending messages to more people at once, please
-        contact us.
+        <a href="{{ contact_page }}">contact us</a>.
         {% endblocktrans %}</p>
+
           <div class="form-group">
             {{form.maximum_recipients.errors}}
             {{form.maximum_recipients.label_tag}}

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -587,6 +587,10 @@ class MessageTogglePublic(RedirectView):
         return reverse('messages_per_writeitinstance', subdomain=self.request.subdomain)
 
 
+class ContactUsView(WriteItInstanceDetailBaseView):
+    template_name = 'nuntium/profiles/contact.html'
+
+
 class WelcomeView(DetailView):
     model = WriteItInstance
     template_name = 'nuntium/profiles/welcome.html'


### PR DESCRIPTION
Add a ‘contact us’ page on the Admin side, and link it up from various places

For now it’s just the team email address — we can make it something more complex later. (Possibly switching on WriteIt vs WriteInPublic too)

![contact us header 2015-04-16 at 21 04 44](https://cloud.githubusercontent.com/assets/57483/7190226/62da2376-e47c-11e4-809b-89efd0ebd71d.png)

![contact us welcome 2015-04-16 at 20 48 12](https://cloud.githubusercontent.com/assets/57483/7190229/62ef8572-e47c-11e4-8664-fb2baec11dd4.png)

![contact us recipients 2015-04-16 at 20 50 40](https://cloud.githubusercontent.com/assets/57483/7190228/62e7b2fc-e47c-11e4-97d7-60e6fa868931.png)



Closes #652 
Closes #944 

<!---
@huboard:{"order":260.0,"milestone_order":1041,"custom_state":""}
-->
