### PR TITLE
Make 'edit' on Test sites go to Welcome

### DIFF
--- a/nuntium/templates/nuntium/profiles/your-instances.html
+++ b/nuntium/templates/nuntium/profiles/your-instances.html
@@ -66,7 +66,7 @@
       <hr />
       <div class="page-header">
         <h2>{% trans "Test Sites" %}</h2>
-        <p>{% trans "Sites are set to Testing Mode by default. Use the menu on the left to make sure that your site is set up in the way that you want it. When you are ready, contact us to let us know and we’ll put your site live." %}</p>
+        <p>{% trans "Sites are set to Testing Mode by default. Use the 'Edit' link and make sure that your site is set up in the way that you want it. When you are ready, contact us to let us know and we’ll put your site live." %}</p>
         
             {% blocktrans count counter=test_sites.count %}
                 This site is in Test Mode:
@@ -101,7 +101,7 @@
             </td>
             <td><a href="{% url 'contacts-per-writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-user"></i> <span class="badge">{{ writeitinstance.persons.count }}</span></a></td>
             <td><a href="{% url 'messages_per_writeitinstance' subdomain=writeitinstance.slug %}"><i class="fa fa-envelope-o"></i> <span class="badge">{{ writeitinstance.message_set.count }}</span></a></td>
-            <td><a href="{% url 'writeitinstance_basic_update' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
+            <td><a href="{% url 'welcome' subdomain=writeitinstance.slug %}"><i class="fa fa-pencil"></i></a></td>
             <td><a href="{% url 'delete_an_instance' subdomain=writeitinstance.slug %}"><i class="fa fa-times"></i></a></td>
           </tr>
           {% empty %}


### PR DESCRIPTION
On the Message Manager, the Edit button for sites that are in Test Mode currently goes to the basic editor (for name + description). Instead, take them to the Welcome page, which provides more information on the whole process of what to edit.


<!---
@huboard:{"order":325.0}
-->
