### PR TITLE
Rename template variables containing 'writeit'.

### DIFF
--- a/mailit/__init__.py
+++ b/mailit/__init__.py
@@ -52,9 +52,9 @@ class MailChannel(OutputPlugin):
             'content_indented': process_content(outbound_message.message.content),
             'person': outbound_message.contact.person.name,
             'author': author_name,
-            'writeit_url': writeitinstance.get_absolute_url(),
+            'site_url': writeitinstance.get_absolute_url(),
             'message_url': outbound_message.message.get_absolute_url(),
-            'writeit_name': writeitinstance.name,
+            'site_name': writeitinstance.name,
             'owner_email': writeitinstance.owner.email,
             }
         text_content = template.get_content_template().format(**context)

--- a/mailit/migrations/0011_rename_variables_without_writeit.py
+++ b/mailit/migrations/0011_rename_variables_without_writeit.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        for template in orm.MailItTemplate.objects.all():
+            template.content_template = template.content_template.replace(u'{writeit_name}', u'{site_name}')
+            template.content_template = template.content_template.replace(u'{writeit_url}', u'{site_url}')
+            template.content_html_template = template.content_html_template.replace(u'{writeit_name}', u'{site_name}')
+            template.content_html_template = template.content_html_template.replace(u'{writeit_url}', u'{site_url}')
+            template.subject_template = template.subject_template.replace(u'{writeit_name}', u'{site_name}')
+            template.subject_template = template.subject_template.replace(u'{writeit_url}', u'{site_url}')
+            template.save()
+            
+    def backwards(self, orm):
+        for template in orm.MailItTemplate.objects.all():
+            template.content_template = template.content_template.replace(u'{site_name}', u'{writeit_name}')
+            template.content_template = template.content_template.replace(u'{site_url}', u'{writeit_url}')
+            template.content_html_template = template.content_html_template.replace(u'{site_name}', u'{writeit_name}')
+            template.content_html_template = template.content_html_template.replace(u'{site_url}', u'{writeit_url}')
+            template.subject_template = template.subject_template.replace(u'{site_name}', u'{writeit_name}')
+            template.subject_template = template.subject_template.replace(u'{site_url}', u'{writeit_url}')
+            template.save()
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'mailit.bouncedmessagerecord': {
+            'Meta': {'object_name': 'BouncedMessageRecord'},
+            'bounce_text': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'mailit.mailittemplate': {
+            'Meta': {'object_name': 'MailItTemplate'},
+            'content_html_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "'{subject}'", 'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'mailit_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'mailit.rawincomingemail': {
+            'Meta': {'object_name': 'RawIncomingEmail'},
+            'answer': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'raw_email'", 'unique': 'True', 'null': 'True', 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2048'}),
+            'problem': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'raw_emails'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['mailit']
+    symmetrical = True

--- a/mailit/templates/mailit/mails/content_template.txt
+++ b/mailit/templates/mailit/mails/content_template.txt
@@ -1,6 +1,6 @@
 Dear {person}
 
-{author} has sent you the following message via {writeit_name} ({writeit_url})
+{author} has sent you the following message via {site_name} ({site_url})
 
 
 {content_indented}

--- a/nuntium/migrations/0065_rename_variables_without_writeit.py
+++ b/nuntium/migrations/0065_rename_variables_without_writeit.py
@@ -1,0 +1,309 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        for template in orm.ConfirmationTemplate.objects.all():
+            template.content_text = template.content_text.replace(u'{writeit_name}', u'{site_name}')
+            template.content_text = template.content_text.replace(u'{writeit_url}', u'{site_url}')
+            template.content_html = template.content_html.replace(u'{writeit_name}', u'{site_name}')
+            template.content_html = template.content_html.replace(u'{writeit_url}', u'{site_url}')
+            template.subject = template.subject.replace(u'{writeit_name}', u'{site_name}')
+            template.subject = template.subject.replace(u'{writeit_url}', u'{site_url}')
+            template.save()
+
+        for template in orm.NewAnswerNotificationTemplate.objects.all():
+            template.template_text = template.template_text.replace(u'{writeit_name}', u'{site_name}')
+            template.template_text = template.template_text.replace(u'{writeit_url}', u'{site_url}')
+            template.template_html = template.template_html.replace(u'{writeit_name}', u'{site_name}')
+            template.template_html = template.template_html.replace(u'{writeit_url}', u'{site_url}')
+            template.subject_template = template.subject_template.replace(u'{writeit_name}', u'{site_name}')
+            template.subject_template = template.subject_template.replace(u'{writeit_url}', u'{site_url}')
+            template.save()
+
+    def backwards(self, orm):
+        for template in orm.ConfirmationTemplate.objects.all():
+            template.content_text = template.content_text.replace(u'{site_name}', u'{writeit_name}')
+            template.content_text = template.content_text.replace(u'{site_url}', u'{writeit_url}')
+            template.content_html = template.content_html.replace(u'{site_name}', u'{writeit_name}')
+            template.content_html = template.content_html.replace(u'{site_url}', u'{writeit_url}')
+            template.subject = template.subject.replace(u'{site_name}', u'{writeit_name}')
+            template.subject = template.subject.replace(u'{site_url}', u'{writeit_url}')
+            template.save()
+
+        for template in orm.NewAnswerNotificationTemplate.objects.all():
+            template.template_text = template.template_text.replace(u'{site_name}', u'{writeit_name}')
+            template.template_text = template.template_text.replace(u'{site_url}', u'{writeit_url}')
+            template.template_html = template.template_html.replace(u'{site_name}', u'{writeit_name}')
+            template.template_html = template.template_html.replace(u'{site_url}', u'{writeit_url}')
+            template.subject_template = template.subject_template.replace(u'{site_name}', u'{writeit_name}')
+            template.subject_template = template.subject_template.replace(u'{site_url}', u'{writeit_url}')
+            template.save()
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerattachment': {
+            'Meta': {'object_name': 'AnswerAttachment'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 4, 21, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2015, 4, 21, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'template_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_create_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'maximum_recipients': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'periodicity': ('django.db.models.fields.CharField', [], {'default': "'1W'", 'max_length': "'2'"}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['nuntium']
+    symmetrical = True

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -417,7 +417,7 @@ class Message(models.Model):
             'recipients': u', '.join([x.name for x in self.people]),
             'subject': self.subject,
             'content': self.content,
-            'writeit_name': self.writeitinstance.name,
+            'site_name': self.writeitinstance.name,
             'url_reject': url_reject,
             'url_accept': url_accept,
             }
@@ -501,7 +501,7 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
             'subject': answer.message.subject,
             'content': answer.content,
             'message_url': message_url,
-            'writeit_name': answer.message.writeitinstance.name,
+            'site_name': answer.message.writeitinstance.name,
             }
 
         subject = new_answer_template.get_subject_template().format(**context)
@@ -732,16 +732,16 @@ class ConfirmationTemplate(models.Model):
     writeitinstance = models.OneToOneField(WriteItInstance)
     content_html = models.TextField(
         blank=True,
-        help_text=_('You can use {author_name}, {writeit_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
+        help_text=_('You can use {author_name}, {site_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
         )
     content_text = models.TextField(
         blank=True,
-        help_text=_('You can use {author_name}, {writeit_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
+        help_text=_('You can use {author_name}, {site_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
         )
     subject = models.CharField(
         max_length=512,
         blank=True,
-        help_text=_('You can use {author_name}, {writeit_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
+        help_text=_('You can use {author_name}, {site_name}, {subject}, {content}, {recipients}, {confirmation_url}, and {message_url}'),
         )
 
     def get_content_template(self):
@@ -790,7 +790,7 @@ def send_confirmation_email(sender, instance, created, **kwargs):
 
         context = {
             'author_name': confirmation.message.author_name,
-            'writeit_name': confirmation.message.writeitinstance.name,
+            'site_name': confirmation.message.writeitinstance.name,
             'subject': confirmation.message.subject,
             'content': confirmation.message.content,
             'recipients': u', '.join([x.name for x in confirmation.message.people]),
@@ -892,16 +892,16 @@ class NewAnswerNotificationTemplate(models.Model):
         )
     template_html = models.TextField(
         blank=True,
-        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {writeit_name}'),
+        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {site_name}'),
         )
     template_text = models.TextField(
         blank=True,
-        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {writeit_name}'),
+        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {site_name}'),
         )
     subject_template = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {writeit_name}'),
+        help_text=_('You can use {author_name}, {person}, {subject}, {content}, {message_url}, and {site_name}'),
         )
 
     def __unicode__(self):

--- a/nuntium/templates/nuntium/mails/confirmation/content_template.txt
+++ b/nuntium/templates/nuntium/mails/confirmation/content_template.txt
@@ -1,17 +1,17 @@
 Hello {author_name}
 
 
-You just submitted a message via {writeit_name}. Please visit the following link to confirm you want to send this message
+You just submitted a message via {site_name}. Please visit the following link to confirm you want to send this message
 
 {confirmation_url}
 
 (If you can’t click the link, try copying and pasting it into your browser’s address bar)
 
-**IMPORTANT** Once confirmed and sent, the message will also be published on {writeit_name}, where your name, your message, and any replies, will be public and online for anyone to read, and will also appear in search engine results.
+**IMPORTANT** Once confirmed and sent, the message will also be published on {site_name}, where your name, your message, and any replies, will be public and online for anyone to read, and will also appear in search engine results.
 
 If this message didn’t come from you (or you’ve changed your mind and don’t want to send it after all) please just ignore this email.
 
-Thanks for using {writeit_name}, and here is a copy of your message for your records:
+Thanks for using {site_name}, and here is a copy of your message for your records:
 
 
 To: {recipients}

--- a/nuntium/templates/nuntium/mails/moderation_mail.txt
+++ b/nuntium/templates/nuntium/mails/moderation_mail.txt
@@ -1,7 +1,7 @@
 Hi {owner_name}
 
 
-Someone just used {writeit_name} to submit a message. Time for some moderation!
+Someone just used {site_name} to submit a message. Time for some moderation!
 
 
 ======================================================================
@@ -24,12 +24,3 @@ Message body:
 **Not so good?** Reject this message at
 
 {url_reject}
-
-
--- 
-
-All the best,
-The WriteIt team
-
-
------

--- a/nuntium/templates/nuntium/mails/moderation_subject.txt
+++ b/nuntium/templates/nuntium/mails/moderation_subject.txt
@@ -1,1 +1,1 @@
-{writeit_name} moderation required: {subject}
+{site_name} moderation required: {subject}

--- a/nuntium/templates/nuntium/mails/new_answer.txt
+++ b/nuntium/templates/nuntium/mails/new_answer.txt
@@ -1,6 +1,6 @@
 Dear {author_name}
 
-{person} has replied to your {writeit_name}
+{person} has replied to your {site_name}
 message with subject
 
 "{subject}"
@@ -12,4 +12,4 @@ You can see their response at
 
 -- 
 
-Thanks for using {writeit_name}
+Thanks for using {site_name}

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -148,7 +148,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
             # Wer'e not including content here until we can include attachments too
             # See #930.
             # 'content': self.answer_content,
-            'writeit_name': 'instance 1',
+            'site_name': 'instance 1',
             'message_url_part': 'thread/subject-1',
             }
 


### PR DESCRIPTION
Replace '{writeit_name}' and '{writeit_url}' in message
templates with '{site_name}' and '{site_url}'.

Fixes #1043.

<!---
@huboard:{"order":715.0,"milestone_order":1050,"custom_state":""}
-->
