### PR TITLE
Clicking twice the confirmation url redirects to the message.

### DIFF
--- a/nuntium/tests/confirmation_test.py
+++ b/nuntium/tests/confirmation_test.py
@@ -179,10 +179,15 @@ class ConfirmationTestCase(TestCase):
             kwargs={'slug': confirmation.key},
             )
         response1 = self.client.get(url)
+        message_thread = reverse(
+            'thread_read', subdomain=self.message.writeitinstance.slug,
+            kwargs={
+                'slug': self.message.slug
+            })
         response2 = self.client.get(url)
 
         self.assertEquals(response1.status_code, 302)
-        self.assertEquals(response2.status_code, 404)
+        self.assertRedirects(response2, message_thread)
 
     def test_i_cannot_access_a_non_confirmed_message(self):
         Confirmation.objects.create(message=self.message)

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -153,11 +153,13 @@ class ConfirmView(RedirectView):
     permanent = False
 
     def get_redirect_url(self, *args, **kwargs):
-        confirmation = get_object_or_404(Confirmation, key=kwargs['slug'], confirmated_at=None)
-        confirmation.confirmated_at = datetime.now()
-        confirmation.save()
-        confirmation.message.recently_confirmated()
-        self.request.session['user_came_via_confirmation_link'] = True
+        confirmation = get_object_or_404(Confirmation, key=kwargs['slug'])
+        # Now proceed with the confirmation
+        if confirmation.confirmated_at is None:
+            confirmation.confirmated_at = datetime.now()
+            confirmation.save()
+            confirmation.message.recently_confirmated()
+            self.request.session['user_came_via_confirmation_link'] = True
         return reverse('thread_read',
             subdomain=confirmation.message.writeitinstance.slug,
             kwargs={'slug': confirmation.message.slug})


### PR DESCRIPTION
This instead of raising a 404 error.
Closes #961