### PR TITLE
This provides a LOGIN_URL forcing it not to use subdomain.

### DIFF
--- a/global_test_case.py
+++ b/global_test_case.py
@@ -14,6 +14,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import RequestFactory
 from django.test.client import Client
 import logging
+from haystack.signals import BaseSignalProcessor
 
 _LOCALS = threading.local()
 
@@ -215,3 +216,7 @@ class WriteItTestRunner(CeleryTestSuiteRunner, NoseTestSuiteRunner):
         logging.disable(logging.CRITICAL)
 
         return super(WriteItTestRunner, self).run_tests(test_labels, extra_tests, **kwargs)
+
+
+class CeleryTestingSignalProcessor(BaseSignalProcessor):
+    pass

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -232,6 +232,7 @@ if TESTING:
 
 #SEARCH INDEX WITH ELASTICSEARCH
 HAYSTACK_SIGNAL_PROCESSOR = 'celery_haystack.signals.CelerySignalProcessor'
+
 if TESTING:
     HAYSTACK_CONNECTIONS = {
         'default': {
@@ -240,6 +241,7 @@ if TESTING:
             'INDEX_NAME': 'haystack-testing',
         },
     }
+    HAYSTACK_SIGNAL_PROCESSOR = 'global_test_case.CeleryTestingSignalProcessor'
 else:
     HAYSTACK_CONNECTIONS = {
         'default': {
@@ -384,6 +386,8 @@ SESSION_COOKIE_DOMAIN = '.127.0.0.1.xip.io'
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_ENABLE_UTC = True
 CELERY_CREATE_MISSING_QUEUES = True
+CELERY_HAYSTACK_TRANSACTION_SAFE = True
+CELERY_HAYSTACK_DEFAULT_TASK = 'celery_haystack.tasks.CeleryHaystackSignalHandler'
 
 # These can be set independently, but most often one will be set to True and
 # the other to False. Setting both to the same boolean value will have
@@ -458,3 +462,10 @@ if 'SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL' in os.environ \
     #         'INDEX_NAME': 'haystack',
     #     },
     # }
+
+from django.db.utils import OperationalError
+try:
+    from subdomains.utils import reverse
+    LOGIN_URL = reverse('login', subdomain=None)
+except OperationalError:
+    LOGIN_URL = '/accounts/login'


### PR DESCRIPTION
So, in the case in which we point to ```http://chile.writeinpublic.com/en/manage```,
the LOGIN_URL in that case will be forced to be ```http://writeinpublic.com/en/accounts/login```,
rather than ```http://chile.writeinpublic.com/en/accounts/login```, which was returning a 404.

This should close #850.