### PR TITLE
Issues/1058/single contact us page

### DIFF
--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -25,7 +25,6 @@ from nuntium.user_section.views import (
     AnswerCreateView,
     AnswerUpdateView,
     ConfirmationTemplateUpdateView,
-    ContactUsView,
     MessageDetail,
     MessagesPerWriteItInstance,
     NewAnswerNotificationTemplateUpdateView,
@@ -90,7 +89,6 @@ managepatterns = patterns('',
     url(r'^messages/(?P<pk>[-\d]+)/toggle-public/$', MessageTogglePublic.as_view(), name='toggle_public'),
     url(r'^moderation_accept/(?P<slug>[-\w]+)/?$', AcceptModerationView.as_view(), name='moderation_accept'),
     url(r'^moderation_reject/(?P<slug>[-\w]+)/?$', RejectModerationView.as_view(), name='moderation_rejected'),
-    url(r'^contact/$', ContactUsView.as_view(), name='contact_us'),
     url(r'^welcome/$', WelcomeView.as_view(), name='welcome'),
 
 )

--- a/nuntium/templates/nuntium/profiles/status-bar.html
+++ b/nuntium/templates/nuntium/profiles/status-bar.html
@@ -1,11 +1,12 @@
 {% load i18n %}
 {% load staticfiles %}
+{% load nuntium_tags %}
 
 {% if writeitinstance.config.testing_mode %}
   <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle"></i> 
       {% url 'welcome' as welcome_page %}
-      {% url 'contact_us' as contact_page %}
+      {% assignment_url_with_subdomain 'contact_us' subdomain=None as contact_page %}
       {% blocktrans %}
         This site is in <a href="{{ welcome_page }}">testing mode.</a>
         All mails will be sent to you, rather than the representatives.

--- a/nuntium/templates/nuntium/profiles/welcome.html
+++ b/nuntium/templates/nuntium/profiles/welcome.html
@@ -1,7 +1,7 @@
 {% extends "base_manager.html" %}
 
 {% load i18n %}
-
+{% load nuntium_tags %}
 {% block content %}
 
 <div class="page-header">
@@ -18,7 +18,7 @@
 </p>
 {% if writeitinstance.config.testing_mode %}
   <p>
-    {% url 'contact_us' as contact_page %}
+    {% assignment_url_with_subdomain 'contact_us' subdomain=None as contact_page %}
     {% blocktrans %}
       You're currently running in <strong>testing mode</strong>, so all
       the emails sent will go to you (and not the recipients).
@@ -36,8 +36,8 @@
       You've got <a href="{{ url_recipients }}">{{ contactable_count }} contactable recipients</a> in your database.
       That‘s great — now you can test out the process of writing to them!
     {% endblocktrans %}
-
-    {% url 'instance_detail' as site_root %}
+    
+    {% assignment_url_with_subdomain 'instance_detail' subdomain=writeitinstance.slug as site_root %}
     {% if writeitinstance.config.testing_mode %}
       {% blocktrans %}Try it out at <a href="{{ site_root }}">your test site</a> —
       don't worry: any emails you send will be sent to <b>you</b>, not

--- a/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_max_recipients_form.html
@@ -1,6 +1,7 @@
 {% extends "base_manager.html" %}
 {% load i18n %}
 {% load staticfiles %}
+{% load nuntium_tags %}
 
 
 {% block header %}
@@ -23,7 +24,7 @@
         be sent to.
         {% endblocktrans %}</p>
 
-        {% url 'contact_us' as contact_page %}
+        {% assignment_url_with_subdomain 'contact_us' subdomain=None as contact_page %}
         <p class="help-block">{% blocktrans %}
         This is limited to a maximum of ten recipients per message. If you
         want to enable sending messages to more people at once, please

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from contactos.models import Contact
 from django.db.models import Q
-
+from subdomains.templatetags.subdomainurls import url as subdomainsurls, UNSET
 register = template.Library()
 
 
@@ -30,3 +30,8 @@ def join_with_commas(obj_list):
         return u"%s" % obj_list[0]
     else:
         return u", ".join(unicode(obj) for obj in obj_list[:list_len - 1]) + u" and " + unicode(obj_list[list_len - 1])
+
+
+@register.assignment_tag(takes_context=True)
+def assignment_url_with_subdomain(context, view, subdomain=UNSET, *args, **kwargs):
+    return subdomainsurls(context, view, subdomain, *args, **kwargs)

--- a/nuntium/tests/contact_us_tests.py
+++ b/nuntium/tests/contact_us_tests.py
@@ -1,0 +1,16 @@
+from global_test_case import GlobalTestCase as TestCase
+from subdomains.utils import reverse
+from django.contrib.auth.models import User
+
+
+class ContactUsTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_the_contact_us_url(self):
+        user = User.objects.get(id=1)
+        url = reverse('contact_us', subdomain=None)
+        self.client.login(username=user.username, password='admin')
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        self.assertTemplateUsed(response, 'nuntium/profiles/contact.html')

--- a/nuntium/urls.py
+++ b/nuntium/urls.py
@@ -7,11 +7,15 @@ from nuntium.views import (
     WriteItInstanceListView,
     )
 
+from nuntium.user_section.views import (
+    ContactUsView,
+)
 
 urlpatterns = patterns('',
     # Examples:
     url(r'^$', HomeTemplateView.as_view(template_name='home.html'), name='home'),
     url(r'^instances/?$', WriteItInstanceListView.as_view(template_name='nuntium/template_list.html'), name='instance_list'),
+    url(r'^contact/$', ContactUsView.as_view(), name='contact_us'),
 
     url(r'^search/?$', MessageSearchView(), name='search_messages'),
 

--- a/nuntium/user_section/tests/template_tags_tests.py
+++ b/nuntium/user_section/tests/template_tags_tests.py
@@ -2,6 +2,8 @@ from django.template import Context, Template
 from global_test_case import GlobalTestCase as TestCase
 from contactos.models import Contact
 from popit.models import Person
+from subdomains.utils import reverse
+from django.template import TemplateSyntaxError
 
 
 class ListContactsTemplateTag(TestCase):
@@ -40,3 +42,26 @@ class ListContactsTemplateTag(TestCase):
             })
         rendered = t.render(c)
         self.assertEquals(u'Pedro, Marcel and Felipe', rendered)
+
+    def test_get_url_using_subdomain(self):
+        '''
+        There is a problem with the subdomain urls wich doesn't allow me to do the following
+        '''
+
+        with self.assertRaises(TemplateSyntaxError):
+            t = Template("{% load subdomainurls %}{% url 'contact_us' subdomain=None as contact_page %}{{contact_page}}")
+            t.render(Context({}))
+
+        '''
+        which is particularly useful when I want to include that url in the blocktrans
+        tag as described in
+
+        https://docs.djangoproject.com/en/1.6/topics/i18n/translation/#blocktrans-template-tag
+        So I was thinking of creating another templatetag to do so.
+        '''
+        expected_template_rendered = reverse('contact_us', subdomain=None)
+
+        t = Template("{% load nuntium_tags %}{% assignment_url_with_subdomain 'contact_us' subdomain=None as contact_page %}{{contact_page}}")
+        actual_template_rendered = t.render(Context({}))
+
+        self.assertEquals(expected_template_rendered, actual_template_rendered)

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -587,7 +587,7 @@ class MessageTogglePublic(RedirectView):
         return reverse('messages_per_writeitinstance', subdomain=self.request.subdomain)
 
 
-class ContactUsView(WriteItInstanceDetailBaseView):
+class ContactUsView(TemplateView):
     template_name = 'nuntium/profiles/contact.html'
 
 


### PR DESCRIPTION
This PR moves the 'contact_us' page to be a system wide page rather than a per instance page.
With this there's also a template tag named ```assignment_url_with_subdomain``` to deal with https://github.com/tkaemming/django-subdomains/issues/25