### PR TITLE
Fixes broken tests due to TEST_POPIT_API_URL variable misisng in writeit...

### DIFF
--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -303,6 +303,12 @@ TEST_POPIT_API_HOST_IP = '127.0.0.1'
 TEST_POPIT_API_PORT = '3000'
 TEST_POPIT_API_SUBDOMAIN = 'popit-django-test'
 
+TEST_POPIT_API_URL = "http://%s.%s.xip.io:%s/api" % (
+    TEST_POPIT_API_SUBDOMAIN,
+    TEST_POPIT_API_HOST_IP,
+    TEST_POPIT_API_PORT,
+    )
+
 # Email settings
 DEFAULT_FROM_EMAIL = 'mailer@example.com'
 


### PR DESCRIPTION
.../settings.py.
The problem here was a mistakenly deleted variable TEST_POPIT_API_URL from the settings.py file.