### PR TITLE
Bug #1070 wrong create your own instance is broken.

### DIFF
--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -463,6 +463,8 @@ if 'SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL' in os.environ \
 
 try:
     from subdomains.utils import reverse
+    from django.utils.translation import activate
+    activate(LANGUAGE_CODE)
     LOGIN_URL = reverse('login', subdomain=None)
 except:
     LOGIN_URL = '/accounts/login'


### PR DESCRIPTION
What this does is set the default login url using the default language, which was causing but #1070.