### PR TITLE
Improve Google Analytics tracking

### DIFF
--- a/nuntium/templates/base.html
+++ b/nuntium/templates/base.html
@@ -67,14 +67,16 @@
     {% block extrajs %}
     {% endblock extrajs %}
     </script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    {% if GOOGLE_ANALYTICS_PROPERTY_ID %}
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-XXXX-Y');  // Replace with your property ID.
-      ga('send', 'pageview');
-    </script>
+          ga('create', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}');
+          ga('send', 'pageview');
+        </script>
+    {% endif %}
 </body>
 </html>

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -130,17 +130,19 @@
     {% block extrajs %}
     {% endblock extrajs %}
     </script>
-    <!-- Google Analytics -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    {% if GOOGLE_ANALYTICS_PROPERTY_ID %}
+        <!-- Google Analytics -->
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-XXXX-Y');  // Replace with your property ID.
-      ga('send', 'pageview');
+          ga('create', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}');
+          ga('send', 'pageview');
 
-    </script>
-    <!-- End Google Analytics -->
+        </script>
+        <!-- End Google Analytics -->
+    {% endif %}
   </body>
 </html>

--- a/nuntium/templates/base_manager.html
+++ b/nuntium/templates/base_manager.html
@@ -138,7 +138,14 @@
           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-          ga('create', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}');
+          {% if request.subdomain %}
+              ga('create', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}', {
+                  'name': '{{ request.subdomain|escapejs }}'
+              });
+              ga('set', 'campaignName', '{{ request.subdomain|escapejs }}');
+          {% else %}
+              ga('create', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}');
+          {% endif %}
           ga('send', 'pageview');
 
         </script>

--- a/writeit/context_processors.py
+++ b/writeit/context_processors.py
@@ -3,3 +3,6 @@ from django.conf import settings
 
 def web_api_settings(request):
     return {'WEB_BASED': settings.WEB_BASED, 'API_BASED': settings.API_BASED}
+
+def google_analytics_settings(request):
+    return {'GOOGLE_ANALYTICS_PROPERTY_ID': settings.GOOGLE_ANALYTICS_PROPERTY_ID}

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -153,6 +153,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'social.apps.django_app.context_processors.backends',
     'social.apps.django_app.context_processors.login_redirect',
     'writeit.context_processors.web_api_settings',
+    'writeit.context_processors.google_analytics_settings',
     )
 
 MIDDLEWARE_CLASSES = (
@@ -367,6 +368,8 @@ INCOMING_EMAIL_LOGGING = 'None'
 EXTRA_APPS = ()
 
 
+GOOGLE_ANALYTICS_PROPERTY_ID = None # Override this in local_settings.py or environment.
+
 # SOCIAL AUTH DETAILS
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = 'Key'
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'S3Cr3t'
@@ -430,6 +433,9 @@ if 'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY' in os.environ:
 
 if 'SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET' in os.environ:
     SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ['SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET']
+
+if 'GOOGLE_ANALYTICS_PROPERTY_ID' in os.environ:
+    GOOGLE_ANALYTICS_PROPERTY_ID = os.environ['GOOGLE_ANALYTICS_PROPERTY_ID']
 
 #Email settings
 if 'DEFAULT_FROM_EMAIL' in os.environ:


### PR DESCRIPTION
This PR:

 - Gets the Google Analytics property ID from `local_settings.py` or environment.
 - Includes the subdomain as the `name` of the GA tracker and as the `campainName` variable that's sent