### PR TITLE
Allow templates to be overridden on a subdomain-specific basis

### DIFF
--- a/writeit/middleware.py
+++ b/writeit/middleware.py
@@ -1,0 +1,35 @@
+import os
+
+from django.conf import settings
+
+class SubdomainTemplateOverrideMiddleware(object):
+    """
+    This middleware manipulates settings.TEMPLATE_DIRS to allow
+    subdomain-specific templates to override the global templates.
+
+    Override templates must be placed within directories named after the
+    subdomain they apply to, within a 'subdomains' directory in any of the
+    paths in settings.TEMPLATE_DIRS.
+
+    For example:
+    To use a custom 'about.html' template for subdomain1.example.org,
+    create your updated about.html in writeit/templates/subdomains/subdomain1/
+
+    This middleware is intended to be used with django-subdomains, and
+    must appear after subdomains.middleware.SubdomainURLRoutingMiddleware.
+    """
+    def process_request(self, request):
+        if hasattr(request, 'subdomain') and request.subdomain is not None:
+            request.OLD_TEMPLATE_DIRS = settings.TEMPLATE_DIRS
+            new_template_dirs = list(settings.TEMPLATE_DIRS)
+            for template_dir in settings.TEMPLATE_DIRS:
+                subdomain_dir = os.path.join(template_dir, "subdomains", request.subdomain)
+                if os.path.isdir(subdomain_dir):
+                    new_template_dirs.insert(0, subdomain_dir)
+            settings.TEMPLATE_DIRS = new_template_dirs
+
+    def process_response(self, request, response):
+        if hasattr(request, 'OLD_TEMPLATE_DIRS'):
+            settings.TEMPLATE_DIRS = request.OLD_TEMPLATE_DIRS
+            del(request.OLD_TEMPLATE_DIRS)
+        return response

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -167,6 +167,7 @@ MIDDLEWARE_CLASSES = (
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'subdomains.middleware.SubdomainURLRoutingMiddleware',
+    'writeit.middleware.SubdomainTemplateOverrideMiddleware',
 )
 
 ROOT_URLCONF = 'nuntium.subdomain_urls'
@@ -181,9 +182,7 @@ SUBDOMAIN_URLCONFS = {
 WSGI_APPLICATION = 'writeit.wsgi.application'
 
 TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
+    os.path.join(BASE_DIR, 'templates'),
 )
 TESTING = 'test' in sys.argv
 

--- a/writeit/templates/subdomains/infoszab/about.html
+++ b/writeit/templates/subdomains/infoszab/about.html
@@ -1,0 +1,96 @@
+{% extends "base_instance.html" %}
+{% load i18n %}
+
+{% block content_inner %}
+
+<h2>About Infoszab</h2>
+
+<p>A new change to the FOI law is going to cause problems in Hungary when
+making requests. Write to the Minister of Justice to express your
+dissatisfaction.</p>
+
+<p>Got a question for a politician? Want to hold someone to account, get
+answers, or just make a point?</p>
+
+<p>We believe that when conversations are held in public, great things
+happen:</p>
+
+<ul>
+  <li>It’s easier to hold people in power to their word.</li>
+  <li>There’s a permanent record of everything that’s been said.</li>
+  <li>You can share the correspondence with anyone, at any time.</li>
+  <li>And all the while, you’re helping to build a public archive of
+  conversations about the things that matter.</li>
+</ul>
+
+<p>That’s why we built {{ writeitinstance.name }}. With just a few clicks 
+you can now send messages to the politicians who represent you.</p>
+
+{% comment "needs #914" %}
+With just a few clicks, you can now send messages to any member of 
+[name of organisation the recipients are in]. </p>
+{% endcomment %}
+
+<h3>How does it work?</h3>
+
+<p>Pick your 
+recipient{% if writeitinstance.config.maximum_recipients > 1 %}s{% endif %},
+compose your letter, and press ‘Send’.</p>
+
+<p>Once you’ve confirmed your email address, we’ll send your message on
+its way, and also publish it on this site for everyone to see.</p>
+
+<p>When you get a reply, we’ll publish that too.</p>
+
+{% comment "needs #263" %}
+Perhaps you’d like to continue the conversation? No problem: just click on ‘reply’, and off
+you go. All in public.</p>
+{% endcomment %}
+
+<h3>How public is ‘public’?</h3>
+
+<p><b>We’ll publish your message, and your name alongside it, on this
+public website.</b> You should be aware that, as a result, your
+message will appear in future searches for your name on search
+engines. Anyone browsing this site will also be able to see it.</p>
+
+<p><b>We encourage the use of real names</b>, although it’s not
+mandatory. Your chosen recipient will be obliged to use his or her real
+name when replying, and we think it’s only right that you extend them
+the same courtesy. If you’re not happy to put your name to a message,
+we’d suggest that you don’t send it.</p>
+
+<p><b>We won’t publish your email address</b>. We ask for it so that we can:</p>
+
+<ul>
+  <li>verify that your message has come from a genuine person, not a
+  spammer or a bot</li>
+  <li>alert you when you receive a reply from your recipient</li>
+  <li>let you know of any issues or problems we may have had sending your
+  message</li>
+  <li>(rarely) send you important information about the site.</li>
+</ul>
+
+{% comment "We don't yet store anywhere who runs a site.." %}
+<h3>Who runs this site?</h3>
+<p>This site is run by [name of organisation] [opportunity to add
+description of their remit if required]</p>
+{% endcomment %}
+
+<h3>How was this site built?</h3>
+
+It runs on the WriteInPublic software, which was developed by 
+<a href="http://ciudadanointeligente.org/">Fundación Ciudadano Inteligente</a> and
+<a href="https://www.mysociety.org/ ">mySociety</a> on top of WriteIt, a
+<a href="http://poplus.org/">Poplus</a> Component.
+
+You can run a site like this too. Find out more at 
+<a href="http://WriteInPublic.com">WriteInPublic.com</a>.
+
+<p></p>
+
+
+{% endblock content_inner %}
+~
+
+


### PR DESCRIPTION
This PR provides a middleware that inspects the subdomain for the current
request (as provided by django-subdomains) and inserts an entry for
subdomain-specific templates to settings.TEMPLATE_DIRS if one exists for
that subdomain.

I've not had to implement a custom template loader because `filesystem.Loader` seems to re-evaluate `TEMPLATE_DIRS` for each request, but that might not be the case in installations other than my local setup. It'd be good to have more eyes on this, specifically when `DEBUG = False`.