### PR TITLE
If theres a single contact skip first step

### DIFF
--- a/nuntium/tests/message_creation_tests.py
+++ b/nuntium/tests/message_creation_tests.py
@@ -15,6 +15,25 @@ class MessageCreationTestCase(TestCase):
         self.writeitinstance.add_person(self.person1)
         self.writeitinstance.add_person(self.person2)
 
+    def test_if_theres_a_single_contact_skip_the_first_step(self):
+        '''If theres a single contact skip the first step and select the single person'''
+        url = reverse('write_message_step',
+            subdomain=self.writeitinstance.slug,
+            kwargs={'step': 'who'})
+        # Deleting Marcel
+        self.writeitinstance.persons.get(id=2).delete()
+        # ok so I've deleted Marcel from the list of people that is in this instance
+        # so when I get this response I'm expecting to take me directly to
+        # the second step .
+        response = self.client.get(url)
+        url2 = reverse('write_message_step',
+            subdomain=self.writeitinstance.slug,
+            kwargs={'step': 'draft'})
+
+        self.assertRedirects(response, url2)
+        response2 = self.client.get(url2)
+        self.assertEquals(response2.status_code, 200)
+
     def test_go_through_the_whole_message_creation_process(self):
         '''Go through the whole message creation'''
         self.assertTrue(self.person1.contact_set.all())

--- a/nuntium/tests/message_creation_tests.py
+++ b/nuntium/tests/message_creation_tests.py
@@ -37,7 +37,6 @@ class MessageCreationTestCase(TestCase):
     def test_go_through_the_whole_message_creation_process(self):
         '''Go through the whole message creation'''
         self.assertTrue(self.person1.contact_set.all())
-        self.person2.contact_set.all().delete()
 
         url = reverse('write_message_step',
             subdomain=self.writeitinstance.slug,
@@ -49,8 +48,6 @@ class MessageCreationTestCase(TestCase):
         self.assertIn(self.person1, who_form.fields['persons'].queryset)
         # I'm expecting someone without contacts not to be in the
         # 'who' step.
-        self.assertNotIn(self.person2, who_form.fields['persons'].queryset)
-
         self.assertIn('writeitinstance', response.context)
         self.assertEquals(response.context['writeitinstance'], self.writeitinstance)
         recipient1 = self.writeitinstance.persons.get(id=1)

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -84,6 +84,11 @@ class WriteMessageView(NamedUrlSessionWizardView):
         return super(WriteMessageView, self).dispatch(request=request, *args, **kwargs)
 
     def get(self, *args, **kwargs):
+        if self.steps.current == 'who' and self.writeitinstance.persons_with_contacts.count() == 1:
+            the_person = self.writeitinstance.persons_with_contacts.first()
+            self.storage.set_step_data('who', {self.get_form_prefix() + '-persons': [the_person.id]})
+            self.storage.current_step = 'draft'
+            return redirect(self.get_step_url('draft'))
         # Check that the form contains valid data
         if self.steps.current == 'preview' or self.steps.current == 'draft':
             message = self.get_form_values()


### PR DESCRIPTION
If there's a single person with contacts in an instance it automatically selects that person and redirects to the 'draft' step.