### PR TITLE
Pin pip packages to fix travis tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ flufl.bounce
 django-markdown-deux
 requests
 django-extensions
-django-haystack
+django-haystack==2.4.0
 django-pipeline
 libsass
-elasticsearch
+elasticsearch==1.6.0
 celery
 pyyaml
 django-celery


### PR DESCRIPTION
Fixing the versions of django-haystack to 2.4.0 and elasticsearch to 1.6.0

@lfalvarez did the work here, I'm just doing the Pull Request :smile: 