### PR TITLE
Allow site creation from EveryPolitician data

### DIFF
--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -161,7 +161,7 @@ class PopitParsingFormMixin(object):
 
 class WriteItInstanceCreateFormPopitUrl(ModelForm, PopitParsingFormMixin):
     popit_url = URLField(
-        label=_('PopIt URL'),
+        label=_('Popolo URL'),
         help_text=_("Example: https://eduskunta.popit.mysociety.org/"),
         required=True,
         )

--- a/nuntium/popit_api_instance.py
+++ b/nuntium/popit_api_instance.py
@@ -28,15 +28,6 @@ def is_current_membership(membership_doc, start_date_key='start_date', end_date_
     return _is_current_membership(start_date, end_date)
 
 
-def get_about(url):
-        try:
-            api = slumber.API(url.replace('/v0.1', ''))
-            response = api.about().get()
-            return response.get('result', {})
-        except slumber.exceptions.HttpClientError:
-            return {}
-
-
 class PopitPerson(Person):
     class Meta:
         proxy = True

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -21,10 +21,16 @@ politicians.</p>
       <option>Select a legislature</option>
       <option disabled></option>
       {% for country in countries %}
-      <option data-slug="{{ country.slug }}" data-email-count="{{ country.people_with_contact_details }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
+      <option
+      data-slug="{{ country.slug }}"
+      data-email-count="{{ country.people_with_contact_details }}"
+      data-person-count="{{ country.person_count }}"
+      value="{{ country.url }}"
+      >{{ country.country }} - {{ country.legislature }}</option>
       {% endfor %}
     </select>
-    <span class="helptext js-not-enough-contact-details">Not enough contact details</span>
+    <span class="helptext js-not-enough-contact-details">No contact details</span>
+    <span class="helptext js-low-contact-count-warning"></span>
   </div>
   <p><a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a></p>
     {% csrf_token %}
@@ -39,6 +45,8 @@ politicians.</p>
   popitUrl.hide();
   var countriesList = $('.js-countries-list');
   var submitButton = $('.js-submit-button');
+  var lowContactCountWarning = $('.js-low-contact-count-warning');
+  lowContactCountWarning.hide();
   submitButton.prop('disabled', true);
   $('.js-show-manual-popolo').click(function(e) {
     e.preventDefault();
@@ -48,13 +56,20 @@ politicians.</p>
   });
   countriesList.change(function(e) {
     notEnoughContactDetails.hide();
+    lowContactCountWarning.hide();
     var option = $('option:selected', this);
     var slug = option.data('slug');
     var emailCount = option.data('email-count');
+    var personCount = option.data('person-count');
     if (emailCount > 0) {
       submitButton.removeAttr('disabled');
       $('#id_popit_url').val($(this).val());
       $('#id_slug').val(slug);
+      if ((emailCount / personCount) <= 0.5) {
+        var text = 'We only have email addresses for ' + emailCount + ' out of ' + personCount + ' people.';
+        lowContactCountWarning.text(text);
+        lowContactCountWarning.show();
+      }
     } else {
       submitButton.prop('disabled', true);
       notEnoughContactDetails.show();

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -21,20 +21,25 @@ politicians.</p>
       <option>Select a legislature</option>
       <option disabled></option>
       {% for country in countries %}
-      <option data-slug="{{ country.slug }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
+      <option data-slug="{{ country.slug }}" data-email-count="{{ country.people_with_contact_details }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
       {% endfor %}
     </select>
+    <span class="helptext js-not-enough-contact-details">Not enough contact details</span>
   </div>
   <p><a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a></p>
     {% csrf_token %}
     {{form.as_p}}
-    <button class='btn btn-primary'>{% trans 'Create' %}</button>
+    <button class='btn btn-primary js-submit-button'>{% trans 'Create' %}</button>
 </form>
 
 <script>
+  var notEnoughContactDetails = $('.js-not-enough-contact-details');
+  notEnoughContactDetails.hide();
   var popitUrl = $('#id_popit_url').closest('p');
   popitUrl.hide();
   var countriesList = $('.js-countries-list');
+  var submitButton = $('.js-submit-button');
+  submitButton.prop('disabled', true);
   $('.js-show-manual-popolo').click(function(e) {
     e.preventDefault();
     popitUrl.show();
@@ -42,8 +47,18 @@ politicians.</p>
     $(this).hide();
   });
   countriesList.change(function(e) {
-    $('#id_popit_url').val($(this).val());
-    $('#id_slug').val($('option:selected', this).data('slug'));
+    notEnoughContactDetails.hide();
+    var option = $('option:selected', this);
+    var slug = option.data('slug');
+    var emailCount = option.data('email-count');
+    if (emailCount > 0) {
+      submitButton.removeAttr('disabled');
+      $('#id_popit_url').val($(this).val());
+      $('#id_slug').val(slug);
+    } else {
+      submitButton.prop('disabled', true);
+      notEnoughContactDetails.show();
+    }
   });
 </script>
 

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -44,13 +44,23 @@ will turn that data into the right format, and create a PopIt for you.
     <option data-slug="{{ country.slug }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
     {% endfor %}
   </select>
+  <a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a>
     {% csrf_token %}
     {{form.as_p}}
     <button class='btn btn-primary'>{% trans 'Create' %}</button>
 </form>
 
 <script>
-  $('.js-countries-list').change(function(e) {
+  var popitUrl = $('#id_popit_url').closest('p');
+  popitUrl.hide();
+  var countriesList = $('.js-countries-list');
+  $('.js-show-manual-popolo').click(function(e) {
+    e.preventDefault();
+    popitUrl.show();
+    countriesList.hide();
+    $(this).hide();
+  });
+  countriesList.change(function(e) {
     $('#id_popit_url').val($(this).val());
     $('#id_slug').val($('option:selected', this).data('slug'));
   });

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -13,38 +13,19 @@
 {% blocktrans %}
 <p>You’re going to make a site that enables people to contact their
 politicians.</p>
-
-<p>You will need:</p>
-
-<ul>
-  <li> Names and contact details for those politicians</li>
-  <li> A <a href="http://popit.poplus.org/">PopIt</a> site to store them in</li>
-</ul>
-
-<p>Both sites work hand in hand: PopIt stores your data, and we fetch the
-names and contact details we need from there.</p>
-
-<h4>No PopIt site?</h4>
-
-Don’t worry, it takes just minutes to set one up. All you need is a spreadsheet with the basic data for your politicians. 
-
-The <a href="http://everypolitician.org/upload/">CSV importer at EveryPolitician</a> 
-will turn that data into the right format, and create a PopIt for you.
-
-<h4>Got your PopIt?</h4>
-
-<p>Great - you’re ready to begin!</p>
-
-<hr>
-
 {% endblocktrans %}
 <form method="POST">
-  <select class="js-countries-list">
-    {% for country in countries %}
-    <option data-slug="{{ country.slug }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
-    {% endfor %}
-  </select>
-  <a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a>
+  <div class="form-group">
+    <label>Legislature</label>
+    <select class="form-control js-countries-list">
+      <option>Select a legislature</option>
+      <option disabled></option>
+      {% for country in countries %}
+      <option data-slug="{{ country.slug }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <p><a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a></p>
     {% csrf_token %}
     {{form.as_p}}
     <button class='btn btn-primary'>{% trans 'Create' %}</button>
@@ -57,7 +38,7 @@ will turn that data into the right format, and create a PopIt for you.
   $('.js-show-manual-popolo').click(function(e) {
     e.preventDefault();
     popitUrl.show();
-    countriesList.hide();
+    countriesList.closest('div').hide();
     $(this).hide();
   });
   countriesList.change(function(e) {

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -38,12 +38,24 @@ will turn that data into the right format, and create a PopIt for you.
 <hr>
 
 {% endblocktrans %}
-
 <form method="POST">
+  <select class="js-countries-list">
+    {% for country in countries %}
+    <option data-slug="{{ country.slug }}" value="{{ country.url }}">{{ country.country }} - {{ country.legislature }}</option>
+    {% endfor %}
+  </select>
     {% csrf_token %}
     {{form.as_p}}
     <button class='btn btn-primary'>{% trans 'Create' %}</button>
 </form>
+
+<script>
+  $('.js-countries-list').change(function(e) {
+    $('#id_popit_url').val($(this).val());
+    $('#id_slug').val($('option:selected', this).data('slug'));
+  });
+</script>
+
 
 {% endblock content %}
 

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -32,7 +32,6 @@ from nuntium.models import (
     default_new_answer_content_template,
     default_new_answer_subject_template,
     )
-from nuntium.popit_api_instance import get_about
 
 from ..forms import (
     WriteItInstanceCreateFormPopitUrl,
@@ -215,11 +214,8 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
         instance = super(WriteItInstanceCreateForm, self).save(commit=False)
         slug = self.cleaned_data['slug']
         instance.slug = slug
+        instance.name = slug
         instance.owner = self.owner
-        popit_url = self.cleaned_data['popit_url']
-        about = get_about(popit_url)
-        subdomain = urlparse(popit_url).netloc.split('.')[0]
-        instance.name = about.get('name', slug)
         instance.save()
         self.relate_with_people()
         return instance

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -182,8 +182,8 @@ class SimpleInstanceCreateFormPopitUrl(WriteItInstanceCreateFormPopitUrl):
 class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
     slug = CharField(
         label=_("The subdomain your site will run at"),
-        help_text=_("Choose wisely; this can't be changed. If you leave this blank, we'll generate one for you."),
-        required=False,
+        help_text=_("Choose wisely; this can't be changed."),
+        required=True,
         min_length=4,
         )
 
@@ -214,13 +214,12 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
     def save(self, commit=True):
         instance = super(WriteItInstanceCreateForm, self).save(commit=False)
         slug = self.cleaned_data['slug']
-        if slug:
-            instance.slug = slug
+        instance.slug = slug
         instance.owner = self.owner
         popit_url = self.cleaned_data['popit_url']
         about = get_about(popit_url)
         subdomain = urlparse(popit_url).netloc.split('.')[0]
-        instance.name = about.get('name', subdomain)
+        instance.name = about.get('name', slug)
         instance.save()
         self.relate_with_people()
         return instance

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -508,7 +508,7 @@ class CreateUserSectionInstanceTestCase(UserSectionTestCase):
         super(CreateUserSectionInstanceTestCase, self).setUp()
         self.user = User.objects.first()
         self.data = {
-            "slug": 'instance',
+            "slug": 'test-instance-slug',
             "popit_url": settings.TEST_POPIT_API_URL,
             }
 
@@ -533,7 +533,7 @@ class CreateUserSectionInstanceTestCase(UserSectionTestCase):
         form = WriteItInstanceCreateForm(data=self.data, owner=self.user)
         instance = form.save()
         self.assertTrue(instance)
-        self.assertEquals(instance.name, "popit-django-test")
+        self.assertEquals(instance.name, "test-instance-slug")
         self.assertEquals(instance.owner, self.user)
         self.assertTrue(instance.persons.all())
 
@@ -544,7 +544,7 @@ class CreateUserSectionInstanceTestCase(UserSectionTestCase):
         url = reverse('create_writeit_instance')
 
         response = c.post(url, data=self.data)
-        instance = WriteItInstance.objects.get(slug='instance', owner=self.user)
+        instance = WriteItInstance.objects.get(slug='test-instance-slug', owner=self.user)
         self.assertRedirects(response, reverse('welcome', subdomain=instance.slug))
         self.assertTrue(instance.persons.all())
 

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -1,3 +1,5 @@
+import requests
+
 from django.contrib.auth.decorators import login_required
 from subdomains.utils import reverse
 from django.http import HttpResponse, Http404
@@ -256,6 +258,11 @@ class WriteItInstanceCreateView(CreateView):
         kwargs = super(WriteItInstanceCreateView, self).get_form_kwargs()
         kwargs['owner'] = self.request.user
         return kwargs
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(WriteItInstanceCreateView, self).get_context_data(*args, **kwargs)
+        context['countries'] = requests.get('https://fake-popit.herokuapp.com/countries.json').json()
+        return context
 
 
 class YourInstancesView(UserSectionListView):

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -261,7 +261,7 @@ class WriteItInstanceCreateView(CreateView):
 
     def get_context_data(self, *args, **kwargs):
         context = super(WriteItInstanceCreateView, self).get_context_data(*args, **kwargs)
-        context['countries'] = requests.get('https://fake-popit.herokuapp.com/countries.json').json()
+        context['countries'] = requests.get('http://everypolitician.github.io/everypolitician-writeinpublic/countries.json').json()
         return context
 
 

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -261,7 +261,9 @@ class WriteItInstanceCreateView(CreateView):
 
     def get_context_data(self, *args, **kwargs):
         context = super(WriteItInstanceCreateView, self).get_context_data(*args, **kwargs)
-        context['countries'] = requests.get('http://everypolitician.github.io/everypolitician-writeinpublic/countries.json').json()
+        countries_json_url = ('http://everypolitician.github.io/'
+            'everypolitician-writeinpublic/countries.json')
+        context['countries'] = requests.get(countries_json_url).json()
         return context
 
 


### PR DESCRIPTION
This allows you to create a site using data pulled from EveryPolitician. It currently does this by giving the user a dropdown list of countries, which are pulled from a proxy app running on heroku. This proxy app then provides a url which WriteInPublic can use to pull EveryPolitician data through an API which looks just like a PopIt API.

![screen shot 2015-10-22 at 13 20 15](https://cloud.githubusercontent.com/assets/22996/10665025/f8d9e83e-78bf-11e5-8016-acb4533a1d4a.png)


Part of #862 