### PR TITLE
Allow import of Popolo JSON file directly

### DIFF
--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -162,7 +162,7 @@ class PopitParsingFormMixin(object):
 class WriteItInstanceCreateFormPopitUrl(ModelForm, PopitParsingFormMixin):
     popit_url = URLField(
         label=_('Popolo URL'),
-        help_text=_("Example: https://eduskunta.popit.mysociety.org/"),
+        help_text=_("Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"),
         required=True,
         )
 

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -17,8 +17,8 @@ politicians.</p>
 <form method="POST">
   <div class="form-group">
     <label>Legislature</label>
-    <select class="form-control js-countries-list">
-      <option>Select a legislature</option>
+    <select name="legislature" class="form-control js-countries-list">
+      <option value="">Select a legislature</option>
       <option disabled></option>
       {% for country in countries %}
       <option

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -50,6 +50,7 @@ politicians.</p>
   submitButton.prop('disabled', true);
   $('.js-show-manual-popolo').click(function(e) {
     e.preventDefault();
+    submitButton.removeAttr('disabled');
     popitUrl.show();
     countriesList.closest('div').hide();
     $(this).hide();

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -81,8 +81,12 @@ politicians.</p>
 {% endblock content %}
 
 {% block extrajs %}
-  $('#id_popit_url').keyup(function () {
-    var generated_slug = this.value.split('/')[2].split('.')[0];
-    $('#id_slug').val(generated_slug.toLowerCase());
+  $('#id_popit_url').keyup(function(e) {
+    var slug = '',
+        domain = this.value.split('/')[2];
+    if (domain) {
+        slug = domain.split('.')[0].toLowerCase();
+    }
+    $('#id_slug').val(slug);
   });
 {% endblock extrajs %}

--- a/nuntium/templates/nuntium/create_new_writeitinstance.html
+++ b/nuntium/templates/nuntium/create_new_writeitinstance.html
@@ -29,7 +29,7 @@ politicians.</p>
       >{{ country.country }} - {{ country.legislature }}</option>
       {% endfor %}
     </select>
-    <span class="helptext js-not-enough-contact-details">No contact details</span>
+    <span class="helptext js-not-enough-contact-details"></span>
     <span class="helptext js-low-contact-count-warning"></span>
   </div>
   <p><a href="#" class="js-show-manual-popolo">I have my own suitably formatted popolo</a></p>
@@ -72,6 +72,7 @@ politicians.</p>
       }
     } else {
       submitButton.prop('disabled', true);
+      notEnoughContactDetails.text('No contact details');
       notEnoughContactDetails.show();
     }
   });

--- a/nuntium/tests/fixtures/vcr_cassettes/default.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/default.yaml
@@ -66,6 +66,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/other_people_with_popolo_emails.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/other_people_with_popolo_emails.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/other_persons.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/other_persons.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/person_with_preferred_email_and_contact_detail.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/person_with_preferred_email_and_contact_detail.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/persons_with_emails.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/persons_with_emails.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/persons_with_memberships.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/persons_with_memberships.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/tests/fixtures/vcr_cassettes/persons_with_null_values.yaml
+++ b/nuntium/tests/fixtures/vcr_cassettes/persons_with_null_values.yaml
@@ -19,6 +19,41 @@
                     ]
                 },
                 "method": "GET",
+                "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"note\": \"This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.\",\n \"info\": {\n \"databaseName\": \"popit_django_test\",\n \"version\": \"0.0.14\" },\n \"meta\": {\n \"persons_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/persons\",\n \"organizations_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/organizations\",\n \"memberships_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/memberships\",\n \"posts_api_url\": \"http://popit-django-test.127.0.0.1.xip.io:3000/api/posts\"\n }\n }"
+                }
+            }
+        },
+        {
+            "request": {
+                "body": null,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "User-Agent": [
+                        "python-requests/2.3.0 CPython/2.7.6 Linux/3.13.0-49-generic"
+                    ]
+                },
+                "method": "GET",
                 "uri": "http://popit-django-test.127.0.0.1.xip.io:3000/api/persons/?per_page=50&page=1"
             },
             "response": {

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -246,7 +246,7 @@ class AnswerForm(ModelForm):
 
 class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
     popit_url = URLField(
-        label=_('PopIt URL'),
+        label=_('Popolo URL'),
         help_text=_("Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"),
         )
 
@@ -264,7 +264,7 @@ class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
         cleaned_data = super(RelatePopitInstanceWithWriteItInstance, self).clean(*args, **kwargs)
         if self.writeitinstance.writeitinstancepopitinstancerecord_set.filter(popitapiinstance__url=cleaned_data.get('popit_url')):
             self.relate()
-            raise ValidationError(_("You have already added this PopIt. But we will fetch the data from it again now."))
+            raise ValidationError(_("You have already added this source. But we will fetch the data from it again now."))
         return cleaned_data
 
 

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -247,7 +247,7 @@ class AnswerForm(ModelForm):
 class RelatePopitInstanceWithWriteItInstance(Form, PopitParsingFormMixin):
     popit_url = URLField(
         label=_('PopIt URL'),
-        help_text=_("Example: https://eduskunta.popit.mysociety.org/"),
+        help_text=_("Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"),
         )
 
     def __init__(self, *args, **kwargs):

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -257,6 +257,9 @@ class WriteItInstanceCreateView(CreateView):
     def get_form_kwargs(self):
         kwargs = super(WriteItInstanceCreateView, self).get_form_kwargs()
         kwargs['owner'] = self.request.user
+        if 'data' in kwargs and kwargs['data'].get('legislature'):
+            kwargs['data'] = kwargs['data'].copy()
+            kwargs['data']['popit_url'] = kwargs['data']['legislature']
         return kwargs
 
     def get_context_data(self, *args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-markdown-deux
 requests
 django-extensions
 django-haystack==2.4.0
-django-pipeline
+django-pipeline==1.5.4
 libsass
 elasticsearch==1.6.0
 celery


### PR DESCRIPTION
It now accepts as well as a popit-style URL (to which it would add /persons and expect paginated data), a popolo JSON file with direct data in persons. The popolo JSON for people should contain id, name, (email), (image), (summary) and memberships either inline or in separate memberships.

Fix some JS-only/JS errors along the way.

Fixes #1105. Fixes #1111.  Fixes #1106. Might be enough for #862.

~~Test failure is in downloading Django, don't know what that's about; passes locally.~~