### PR TITLE
Previously if there was a KeyError with a template, it made the entir…

### DIFF
--- a/mailit/__init__.py
+++ b/mailit/__init__.py
@@ -57,9 +57,20 @@ class MailChannel(OutputPlugin):
             'site_name': writeitinstance.name,
             'owner_email': writeitinstance.owner.email,
             }
-        text_content = template.get_content_template().format(**context)
-        html_content = template.content_html_template.format(**escape_dictionary_values(context))
-        subject = template.subject_template.format(**context)
+        try:
+            text_content = template.get_content_template().format(**context)
+            html_content = template.content_html_template.format(**escape_dictionary_values(context))
+            subject = template.subject_template.format(**context)
+        except KeyError, error:
+            log = "Error with templates for instance %(instance)s and the error was '%(error)s'"
+            log = log % {
+                'instance': writeitinstance.name,
+                'error': error.__unicode__()
+                }
+            mail_admins("Problem sending an email", log)
+            logging.info(log)
+            return False, True
+
 
         if settings.SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL:
             from_email = author_name + " <" + settings.DEFAULT_FROM_EMAIL + ">"

--- a/nuntium/tests/tasks_test.py
+++ b/nuntium/tests/tasks_test.py
@@ -53,6 +53,20 @@ class TasksTestCase(TestCase):
             send_mails_task()  # It returns a result
             info.assert_called_with(expected_log)
 
+    def test_handling_unexpected_exceptions_in_send(self):
+        for outbound_message in OutboundMessage.objects.all():
+            outbound_message.status = "ready"
+            outbound_message.save()
+
+        instance = WriteItInstance.objects.get(id=1)
+        instance.mailit_template.content_template = '{autor}'
+        instance.mailit_template.save()
+
+        send_mails_task()
+
+        other_instance = WriteItInstance.objects.get(id=2)
+        self.assertTrue(OutboundMessage.objects.filter(message__writeitinstance=other_instance, status="sent"))
+
 
 class PullFromPopitTask(TestCase):
     def setUp(self):


### PR DESCRIPTION
…e send_mails task crash.

This commit prevents that problem.

This fixes #1115.