### PR TITLE
Only specify one way of running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ LOCAL_ELASTICSEARCH = False
 Running tests
 --------------
 
-For testing you need to run ```./test.py```
+For testing you need to run ```./manage.py test nuntium contactos mailit```
 
 Coverage Analysis
 -----------------

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from django.core.management import call_command
-import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "writeit.settings")
-call_command('test', 'nuntium', 'contactos', 'mailit', verbosity=1)


### PR DESCRIPTION
When I first created a new Vagrant box I read the readme and it said to run
`./test.py` but that didn't work. Then I noticed in the motd when you login to
the Vagrant box it says to us a different command. This is confusing so this
commit gets rid of that extra command and just documents the one way of running
tests.

Fixes #1117