### PR TITLE
Allow search tests to run successfully on fresh Vagrant box

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-extensions
 django-haystack==2.4.0
 django-pipeline==1.5.4
 libsass
-elasticsearch==1.6.0
+elasticsearch<1.0.0
 celery
 pyyaml
 django-celery


### PR DESCRIPTION
Lock elasticsearch-py below v1.x so it's compatible with Elasticsearch 0.90.x

The Vagrant box currently has elasticsearch version 0.90.13 installed so we need
to use an elasticsearch-py version from 0.4.x releases. For more information:

* https://django-haystack.readthedocs.org/en/v2.4.0/installing_search_engines.html#elasticsearch
* https://pypi.python.org/pypi/elasticsearch/1.6.0#compatibility