### PR TITLE
Ensure django_admin_bootstrapped is a version compatible with Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pyyaml
 django-celery
 django-autoslug
 pytz>=2013b
-django-admin-bootstrapped
+django-admin-bootstrapped==2.3.6
 django-object-actions
 unidecode
 python-social-auth==0.2.3


### PR DESCRIPTION
This locks django_admin_bootstrapped at 2.3.6, which is compatible with our
version of Django, 1.6. It means form fields in the admin are actually visible
so you can see and edit them.

Fixes #1123