### PR TITLE
Update vagrant JDK install to match elasticsearch expected version

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -28,7 +28,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   git libffi-dev libssl-dev build-essential yui-compressor sqlite3 postfix \
   python-dev python-pip python-virtualenv \
   rabbitmq-server \
-  openjdk-6-jre elasticsearch \
+  openjdk-7-jre elasticsearch \
   mongodb-org nodejs
 
 # Set virtualenv directory and create it if needed.


### PR DESCRIPTION
The current version of elasticsearch relies on Java 7 and silently fails
to launch which Java 6 so install Open JDK 7