### PR TITLE
Add can_create_messages property to instances

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -136,8 +136,17 @@ class WriteItInstance(models.Model):
             result[record.status] += 1
         return result
 
+    @property
+    def can_create_messages(self):
+        if self.config.allow_messages_using_form and \
+                self.contacts.exists():
+            return True
+
+        return False
+
     def __unicode__(self):
         return self.name
+
 
 
 def new_write_it_instance(sender, instance, created, **kwargs):

--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -32,7 +32,7 @@
                 <ul>
                     <li class="site-header__nav__link"><a href="{% url 'instance_detail' subdomain=writeitinstance.slug %}">{% trans "Home" %}</a></li>
                     <li class="site-header__nav__link"><a href="{% url 'about' subdomain=writeitinstance.slug %}">{% trans "About" %}</a></li>
-                  {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
+                  {% if writeitinstance.can_create_messages %}
                     <li class="site-header__nav__link"><a href="{% url 'write_message' subdomain=writeitinstance.slug %}">{% trans "Send a message" %}</a></li>
                   {% endif %}
                     <li class="site-header__nav__link"><a href="{% url 'message_threads' subdomain=writeitinstance.slug %}">{% trans "Browse messages" %}</a></li>

--- a/nuntium/templates/nuntium/instance_detail.html
+++ b/nuntium/templates/nuntium/instance_detail.html
@@ -15,7 +15,7 @@
                 <h2 class="instance-hero__heading">
                     {{ writeitinstance.description|default:_("Write to the people who represent you.<br />In public.<br /><br />Get answers.<br />In public.") }}
                 </h2>
-                {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
+                {% if writeitinstance.can_create_messages %}
                     <a class="btn btn-primary btn-lg" href="{% url 'write_message' subdomain=writeitinstance.slug %}">{% trans "Send a message" %}</a>
                 {% endif %}
             </div>

--- a/nuntium/templates/thread/to.html
+++ b/nuntium/templates/thread/to.html
@@ -21,7 +21,7 @@
             <p class="results__actions__info">{{ person.summary }}</p>
           {% endif %}
 
-          {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
+          {% if writeitinstance.can_create_messages %}
             <form action="{% url 'write_message_step' step='who' %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="write_message_view-current_step" value="who">

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -18,7 +18,7 @@
 
 {% block content_inner %}
 
-  {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
+  {% if writeitinstance.can_create_messages %}
 
     {% include "write/breadcrumb.html" with current_step=1 %}
 

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -136,6 +136,29 @@ class InstanceTestCase(TestCase):
 
         popit_api_instance, created = PopitApiInstance.objects.get_or_create(url=settings.TEST_POPIT_API_URL)
 
+    @popit_load_data()
+    def test_can_create_messages(self):
+        writeitinstance = WriteItInstance.objects.create(name='instance 1', slug='instance-1', owner=self.owner)
+
+        self.assertTrue(writeitinstance.config.allow_messages_using_form)
+        self.assertFalse(writeitinstance.can_create_messages)
+        writeitinstance.load_persons_from_a_popit_api(settings.TEST_POPIT_API_URL)
+
+        email_type = ContactType.objects.get(id=1)
+        person = Person.objects.get(id=1)
+        Contact.objects.create(
+            person=person,
+            contact_type=email_type,
+            writeitinstance=writeitinstance,
+            value='email@mail.com',
+            )
+        self.assertEquals(writeitinstance.contacts.all().count(), 1)
+        self.assertTrue(writeitinstance.can_create_messages)
+
+        writeitinstance.config.allow_messages_using_form = False
+        self.assertFalse(writeitinstance.config.allow_messages_using_form)
+        self.assertFalse(writeitinstance.can_create_messages)
+
 
 class PersonsWithContactsTestCase(TestCase):
     def setUp(self):

--- a/writeit/templates/subdomains/infoszab/nuntium/instance_detail.html
+++ b/writeit/templates/subdomains/infoszab/nuntium/instance_detail.html
@@ -11,7 +11,7 @@
                 <h2 class="instance-hero__heading">
                     Hétfőn szavaz a Parlament az információszabadság-törvény módosításáról. Ha elfogadják a javaslatot, akkor nehezebb és drágább lesz hozzáférni a közérdekű adatokhoz. <br /><br />Ha szeretné tudni,  mire fordítják az adóját, írjon levelet az igazságügyi miniszternek. Kérje a törvénymódosítás visszavonását.<br />
                 </h2>
-                {% if writeitinstance.contacts.exists and writeitinstance.config.allow_messages_using_form %}
+                {% if writeitinstance.can_create_messages %}
                     <a class="btn btn-primary btn-lg" href="{% url 'write_message' subdomain=writeitinstance.slug %}">{% trans "Send a message" %}</a>
                 {% endif %}
             </div>


### PR DESCRIPTION
Use this in the templates to determine if we can send messages rather
than checking for contacts and enabled.

Fixes #891