### PR TITLE
Allow instances to set a default language

### DIFF
--- a/example_data.yaml
+++ b/example_data.yaml
@@ -22,10 +22,10 @@
 - fields: {name: instance 2, slug: instance2, owner: 1}
   model: nuntium.writeitinstance
   pk: 2
-- fields: {testing_mode: false, writeitinstance: 1}
+- fields: {testing_mode: false, writeitinstance: 1, default_language: 'en'}
   model: nuntium.writeitinstanceconfig
   pk: 1
-- fields: {testing_mode: false, writeitinstance: 2}
+- fields: {testing_mode: false, writeitinstance: 2, default_language: 'es'}
   model: nuntium.writeitinstanceconfig
   pk: 2
 - fields: {content: Content 1, subject: Subject 1, confirmated: False, writeitinstance: 1, slug: subject-1, author_name: Fiera, author_email: fiera@ciudadanointeligente.org }

--- a/nuntium/middleware.py
+++ b/nuntium/middleware.py
@@ -13,9 +13,21 @@ class InstanceLocaleMiddleware(LocaleMiddleware):
         except WriteItInstanceConfig.DoesNotExist:
             default_language = settings.LANGUAGE_CODE
 
+        # Django 1.6 doesn't provide a nice way to hook into the language
+        # selection process to override it with a default. So instead we add
+        # a default language to the session and then remove it again after
+        # running 'get_language_from_request'.
+        did_override_session_language = False
+
         if not request.session.get('django_language', None):
             request.session['django_language'] = default_language
+            did_override_session_language = True
+
         language = translation.get_language_from_request(
             request, check_path=check_path)
+
+        if did_override_session_language:
+            del request.session['django_language']
+
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()

--- a/nuntium/middleware.py
+++ b/nuntium/middleware.py
@@ -1,0 +1,21 @@
+from django.middleware.locale import LocaleMiddleware
+from django.utils import translation
+from django.conf import settings
+
+from nuntium.models import WriteItInstanceConfig
+
+
+class InstanceLocaleMiddleware(LocaleMiddleware):
+    def process_request(self, request):
+        check_path = self.is_language_prefix_patterns_used()
+        try:
+            default_language = WriteItInstanceConfig.objects.get(writeitinstance__slug=request.subdomain).default_language
+        except WriteItInstanceConfig.DoesNotExist:
+            default_language = settings.LANGUAGE_CODE
+
+        if not request.session.get('django_language', None):
+            request.session['django_language'] = default_language
+        language = translation.get_language_from_request(
+            request, check_path=check_path)
+        translation.activate(language)
+        request.LANGUAGE_CODE = translation.get_language()

--- a/nuntium/middleware.py
+++ b/nuntium/middleware.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django.middleware.locale import LocaleMiddleware
 from django.utils import translation
 from django.conf import settings
@@ -5,29 +7,30 @@ from django.conf import settings
 from nuntium.models import WriteItInstanceConfig
 
 
+def get_language_from_request(request, check_path=False):
+    supported = OrderedDict(settings.LANGUAGES)
+
+    if check_path:
+        lang_code = translation.get_language_from_path(request.path_info, supported)
+        if lang_code is not None:
+            return lang_code
+
+    try:
+        lang_code = WriteItInstanceConfig.objects.get(writeitinstance__slug=request.subdomain).default_language
+    except WriteItInstanceConfig.DoesNotExist:
+        lang_code = None
+
+    if lang_code in supported and lang_code is not None and translation.check_for_language(lang_code):
+        return lang_code
+
+    # Call with check_path False as we've already done that above!
+    return translation.get_language_from_request(request, check_path=False)
+
+
 class InstanceLocaleMiddleware(LocaleMiddleware):
     def process_request(self, request):
+        """Same as parent, except calling our own get_language_from_request"""
         check_path = self.is_language_prefix_patterns_used()
-        try:
-            default_language = WriteItInstanceConfig.objects.get(writeitinstance__slug=request.subdomain).default_language
-        except WriteItInstanceConfig.DoesNotExist:
-            default_language = settings.LANGUAGE_CODE
-
-        # Django 1.6 doesn't provide a nice way to hook into the language
-        # selection process to override it with a default. So instead we add
-        # a default language to the session and then remove it again after
-        # running 'get_language_from_request'.
-        did_override_session_language = False
-
-        if not request.session.get('django_language', None):
-            request.session['django_language'] = default_language
-            did_override_session_language = True
-
-        language = translation.get_language_from_request(
-            request, check_path=check_path)
-
-        if did_override_session_language:
-            del request.session['django_language']
-
+        language = get_language_from_request(request, check_path=check_path)
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()

--- a/nuntium/migrations/0066_auto__add_field_writeitinstanceconfig_default_language.py
+++ b/nuntium/migrations/0066_auto__add_field_writeitinstanceconfig_default_language.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'WriteItInstanceConfig.default_language'
+        db.add_column(u'nuntium_writeitinstanceconfig', 'default_language',
+                      self.gf('django.db.models.fields.CharField')(default='en', max_length=10),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'WriteItInstanceConfig.default_language'
+        db.delete_column(u'nuntium_writeitinstanceconfig', 'default_language')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerattachment': {
+            'Meta': {'object_name': 'AnswerAttachment'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2016, 3, 30, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2016, 3, 30, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'template_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['nuntium.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_create_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'default_language': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'maximum_recipients': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'nuntium.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'periodicity': ('django.db.models.fields.CharField', [], {'default': "'1W'", 'max_length': "'2'"}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['nuntium']

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -188,6 +188,7 @@ class WriteItInstanceConfig(models.Model):
     email_use_ssl = models.NullBooleanField()
     can_create_answer = models.BooleanField(default=False, help_text="Can create an answer using the WebUI")
     maximum_recipients = models.PositiveIntegerField(default=5)
+    default_language = models.CharField(max_length=10, choices=settings.LANGUAGES)
 
     def get_mail_connection(self):
         connection = mail.get_connection()

--- a/nuntium/templates/nuntium/profiles/welcome.html
+++ b/nuntium/templates/nuntium/profiles/welcome.html
@@ -86,7 +86,7 @@
         {% endblocktrans %}
       {% else %}
         {% blocktrans with desc=writeitinstance.description %}
-          <a href="{{ url_basic_update }}">set the description</a>
+          <a href="{{ url_basic_update }}">set the description and default language</a>
         {% endblocktrans %}
       {% endif %}
     </p>

--- a/nuntium/templates/nuntium/writeitinstance_update_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_update_form.html
@@ -32,6 +32,10 @@
         {{ form.description.label_tag }}
         {{ form.description }}
       </div>
+      <div class="form-group">
+        {{ form.language.label_tag }}
+        {{ form.language }}
+      </div>
 
       <div class="save-bar">
         <input type="submit" class='btn btn-primary' value="{% trans 'Save changes' %}" />

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from urlparse import urlsplit, urlunsplit
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
 from subdomains.utils import reverse
 from nuntium.models import WriteItInstance, Message, Membership, Confirmation
@@ -76,6 +77,26 @@ class InstanceTestCase(TestCase):
         response = self.client.get(writeitinstance1.get_absolute_url())
         self.assertEquals(response.status_code, 200)
         self.assertTemplateUsed(response, 'nuntium/instance_detail.html')
+
+    def test_redirected_to_instance_default_language(self):
+        writeitinstance2 = WriteItInstance.objects.get(id=2)
+        url = reverse('instance_detail', subdomain=writeitinstance2.slug)
+        uri = list(urlsplit(url))
+        uri[2] = '/'
+        url = urlunsplit(uri)
+        response = self.client.get(url)
+        uri[2] = '/es/'
+        url = urlunsplit(uri)
+        self.assertRedirects(response, url)
+
+    def test_no_redirect_with_specified_language(self):
+        writeitinstance2 = WriteItInstance.objects.get(id=2)
+        url = reverse('instance_detail', subdomain=writeitinstance2.slug)
+        uri = list(urlsplit(url))
+        uri[2] = '/cs/'
+        url = urlunsplit(uri)
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
 
     def test_get_non_existing_instance(self):
         url = reverse('instance_detail',

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -14,6 +14,7 @@ from django.forms import (
     Textarea,
     URLField,
     ValidationError,
+    ChoiceField,
     )
 
 from django.utils.translation import ugettext as _
@@ -41,6 +42,18 @@ from ..forms import (
 
 
 class WriteItInstanceBasicForm(ModelForm):
+    language = ChoiceField(choices=settings.LANGUAGES)
+
+    def __init__(self, *args, **kwargs):
+        kwargs['initial']['language'] = kwargs['instance'].config.default_language
+        super(WriteItInstanceBasicForm, self).__init__(*args, **kwargs)
+
+    def save(self, *args, **kwargs):
+        ret = super(WriteItInstanceBasicForm, self).save(*args, **kwargs)
+        ret.config.default_language = self.cleaned_data['language']
+        ret.config.save()
+        return ret
+
     class Meta:
         model = WriteItInstance
         fields = ['name', 'description']

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -45,7 +45,10 @@ class WriteItInstanceBasicForm(ModelForm):
     language = ChoiceField(choices=settings.LANGUAGES)
 
     def __init__(self, *args, **kwargs):
-        kwargs['initial']['language'] = kwargs['instance'].config.default_language
+        try:
+            kwargs['initial']['language'] = kwargs['instance'].config.default_language
+        except KeyError:
+            pass
         super(WriteItInstanceBasicForm, self).__init__(*args, **kwargs)
 
     def save(self, *args, **kwargs):

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -231,6 +231,8 @@ class WriteItInstanceCreateForm(WriteItInstanceCreateFormPopitUrl):
         instance.name = slug
         instance.owner = self.owner
         instance.save()
+        instance.config.default_language = settings.LANGUAGE_CODE
+        instance.config.save()
         self.relate_with_people()
         return instance
 

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -15,6 +15,7 @@ from django.forms import (
     URLField,
     ValidationError,
     ChoiceField,
+    Select,
     )
 
 from django.utils.translation import ugettext as _
@@ -42,7 +43,7 @@ from ..forms import (
 
 
 class WriteItInstanceBasicForm(ModelForm):
-    language = ChoiceField(choices=settings.LANGUAGES)
+    language = ChoiceField(choices=settings.LANGUAGES, widget=Select(attrs={'class':'form-control'}))
 
     def __init__(self, *args, **kwargs):
         try:

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -306,27 +306,6 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
         response = client.get(url)
         self.assertRedirectToLogin(response, next_url=url)
 
-    def test_writeitinstance_basic_form(self):
-        form = WriteItInstanceBasicForm()
-        self.assertEquals(form._meta.model, WriteItInstance)
-        self.assertEquals(form._meta.fields, ['name', 'description'])
-
-    def test_writeitinstance_basic_form_save(self):
-        data = {
-            'name': 'name 1',
-            'maximum_recipients': 5,
-            'rate_limiter': 0,
-            }
-        url = reverse('writeitinstance_basic_update', subdomain=self.writeitinstance.slug)
-        c = self.client
-        c.login(username=self.owner.username, password='admin')
-        response = c.post(url, data=data)
-        # self.assertEquals(response.status_code, 200)
-        self.assertRedirects(response, url)
-        writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
-        self.assertEquals(writeitinstance.name, data['name'])
-        self.assertEquals(writeitinstance.config.maximum_recipients, data['maximum_recipients'])
-
     def test_when_a_non_owner_saves_it_does_not_get_200_status_code(self):
         # I think that this test is unnecesary but
         # it could be of some use in the future
@@ -406,14 +385,17 @@ class WriteitInstanceUpdateTestCase(UserSectionTestCase):
         data = {
             'name': 'new name',
             'description': 'new description',
+            'language': 'cs',
             }
         url = reverse('writeitinstance_basic_update', subdomain=self.writeitinstance.slug)
         c = self.client
         c.login(username=self.owner.username, password='admin')
-        c.post(url, data=data)
+        response = c.post(url, data=data)
+        self.assertRedirects(response, url)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
         self.assertEquals(writeitinstance.name, data['name'])
         self.assertEquals(writeitinstance.description, data['description'])
+        self.assertEquals(writeitinstance.config.default_language, data['language'])
 
 
 class WriteItInstanceApiDocsTestCase(UserSectionTestCase):

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -165,12 +165,12 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    'subdomains.middleware.SubdomainURLRoutingMiddleware',
+    'nuntium.middleware.InstanceLocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'pagination.middleware.PaginationMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'subdomains.middleware.SubdomainURLRoutingMiddleware',
     'writeit.middleware.SubdomainTemplateOverrideMiddleware',
 )
 


### PR DESCRIPTION
![screen shot 2016-03-30 at 16 18 30](https://cloud.githubusercontent.com/assets/22996/14147382/18a1db9e-f693-11e5-97a7-8755c8a3f659.png)


This adds a piece of middleware which checks the instance for a default language and sets that on the request if there isn't a translation for the users' default language.

Fixes https://github.com/ciudadanointeligente/write-it/issues/1091