### PR TITLE
Update base Ubuntu OS from 12.04 to 14.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $post_up_message = "** Your Vagrant box is ready to use! \o/ **
 Log in (with 'vagrant ssh') and follow the instructions."
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/trusty64"
 
   # Enable NFS access to the disk
   config.vm.synced_folder "", "/vagrant", nfs: true

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -64,7 +64,7 @@ Run the tests with:
   ./manage.py test nuntium contactos mailit
 
 -------------------------------------------------------
-" | sudo tee /etc/motd.tail > /dev/null
+" | sudo tee /etc/motd > /dev/null
 
 # Add cd /vagrant to ~/.bashrc
 grep -qG "cd /vagrant" "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"


### PR DESCRIPTION
Seems that the hashicorp boxes aren't updated anymore, so first boot is quite long. The ubuntu boxes are the more widely used ones now.

And the `motd` file changed a bit.

I suspect that en_GB isn't preloaded on this image. Is it alright is I switch that to `en_US`. I'm Canadian, so I dislike this just as much as you ;)