### PR TITLE
Pin django-nose to the last version that works with Django < 1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-admin-bootstrapped==2.3.6
 django-object-actions
 unidecode
 python-social-auth==0.2.3
-django-nose
+django-nose==1.4.3
 mock==1.0.1
 python-dateutil
 #things required in heroku

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,4 +1,4 @@
 coveralls
 mock==1.0.1
-django-nose
+django-nose==1.4.3
 prospector


### PR DESCRIPTION
As of django-nose/django-nose@7f205f1b16e641a7b1 support for Django
earlier than 1.7 was dropped, but write-it is still using Django
1.6.10 (which is no longer supported, but that's another issue: #718)
django-nose 1.4.3 is the last version that works with Django 1.6.