### PR TITLE
Switch to using container-based builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Build on Travis's container-based infrastructure, which starts builds
+# much faster:
+sudo: false
+
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
These are much faster to start up than builds on the legacy
infrastructure; the .travis.yml doesn't use sudo anyway, so this should
work fine.