### PR TITLE
Move some models to a new instance app to avoid circular dependencies

### DIFF
--- a/contactos/migrations/0008_move_to_instance.py
+++ b/contactos/migrations/0008_move_to_instance.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Contact.writeitinstance'
+        db.alter_column(u'contactos_contact', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(null=True, to=orm['instance.WriteItInstance']))
+
+    def backwards(self, orm):
+
+        # Changing field 'Contact.writeitinstance'
+        db.alter_column(u'contactos_contact', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(null=True, to=orm['nuntium.WriteItInstance']))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'instance.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'instance.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['instance.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['contactos']

--- a/contactos/models.py
+++ b/contactos/models.py
@@ -25,7 +25,7 @@ class Contact(models.Model):
     value = models.CharField(max_length=512)
     is_bounced = models.BooleanField(default=False)
     owner = models.ForeignKey(User, related_name="contacts", null=True)
-    writeitinstance = models.ForeignKey('nuntium.WriteItInstance', related_name="contacts", null=True)
+    writeitinstance = models.ForeignKey('instance.WriteItInstance', related_name="contacts", null=True)
     popit_identifier = models.CharField(max_length=512, null=True)
     enabled = models.BooleanField(default=True)
 

--- a/contactos/tests/contacts_tests.py
+++ b/contactos/tests/contacts_tests.py
@@ -14,7 +14,7 @@ from django.test.client import RequestFactory, Client
 from django.forms import ModelForm
 from subdomains.utils import reverse
 import simplejson as json
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from django.db.models import Q
 from django.contrib.sites.models import Site
 

--- a/contactos/views.py
+++ b/contactos/views.py
@@ -6,7 +6,7 @@ import simplejson as json
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from popit.models import Person
 from django.http import Http404
 

--- a/example_data.yaml
+++ b/example_data.yaml
@@ -17,16 +17,16 @@
   model: auth.user
   pk: 1
 - fields: {name: instance 1, slug: instance1, owner: 1}
-  model: nuntium.writeitinstance
+  model: instance.writeitinstance
   pk: 1
 - fields: {name: instance 2, slug: instance2, owner: 1}
-  model: nuntium.writeitinstance
+  model: instance.writeitinstance
   pk: 2
 - fields: {testing_mode: false, writeitinstance: 1, default_language: 'en'}
-  model: nuntium.writeitinstanceconfig
+  model: instance.writeitinstanceconfig
   pk: 1
 - fields: {testing_mode: false, writeitinstance: 2, default_language: 'es'}
-  model: nuntium.writeitinstanceconfig
+  model: instance.writeitinstanceconfig
   pk: 2
 - fields: {content: Content 1, subject: Subject 1, confirmated: False, writeitinstance: 1, slug: subject-1, author_name: Fiera, author_email: fiera@ciudadanointeligente.org }
   model: nuntium.message
@@ -77,10 +77,10 @@
   model: nuntium.answer
   pk: 2
 - fields: {person: 1, writeitinstance: 1}
-  model: nuntium.membership
+  model: instance.membership
   pk: 1
 - fields: {person: 1, writeitinstance: 2}
-  model: nuntium.membership
+  model: instance.membership
   pk: 2
 - fields: {label_name: Electronic Mail, name: e-mail}
   model: contactos.contacttype

--- a/instance/migrations/0001_move_to_instance.py
+++ b/instance/migrations/0001_move_to_instance.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    depends_on = (
+        ('nuntium', '0066_auto__add_field_writeitinstanceconfig_default_language'),
+    )
+
+    def forwards(self, orm):
+        db.rename_table('nuntium_writeitinstance', 'instance_writeitinstance')
+        db.rename_table('nuntium_membership', 'instance_membership')
+        db.rename_table('nuntium_writeitinstancepopitinstancerecord', 'instance_writeitinstancepopitinstancerecord')
+        db.rename_table('nuntium_writeitinstanceconfig', 'instance_writeitinstanceconfig')
+
+        if not db.dry_run:
+            # For permissions to work properly after migrating
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='nuntium',
+                model__in=(
+                    'writeitinstance',
+                    'membership',
+                    'writeitinstancepopitinstancerecord',
+                    'writeitinstanceconfig',
+                )
+            ).update(app_label='instance')
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'instance.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'instance.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['instance.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'instance.writeitinstanceconfig': {
+            'Meta': {'object_name': 'WriteItInstanceConfig'},
+            'allow_messages_using_form': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autoconfirm_api_messages': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_create_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_from_domain': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'default_language': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'email_host': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_password': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_host_user': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'email_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_ssl': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'email_use_tls': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'maximum_recipients': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'moderation_needed_in_all_messages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notify_owner_when_new_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rate_limiter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'testing_mode': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'writeitinstance': ('annoying.fields.AutoOneToOneField', [], {'related_name': "'config'", 'unique': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'instance.writeitinstancepopitinstancerecord': {
+            'Meta': {'object_name': 'WriteitInstancePopitInstanceRecord'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'periodicity': ('django.db.models.fields.CharField', [], {'default': "'1W'", 'max_length': "'2'"}),
+            'popitapiinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'nothing'", 'max_length': "'20'"}),
+            'status_explanation': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['instance']

--- a/instance/models.py
+++ b/instance/models.py
@@ -1,0 +1,213 @@
+import datetime
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core import mail
+from django.db import models
+from django.db.models.signals import post_save
+from django.utils.translation import ugettext_lazy as _
+
+from annoying.fields import AutoOneToOneField
+from autoslug import AutoSlugField
+from nuntium.popit_api_instance import PopitApiInstance
+from popit.models import Person, ApiInstance
+from requests.exceptions import ConnectionError
+from subdomains.utils import reverse
+
+
+class WriteItInstance(models.Model):
+    """WriteItInstance: Entity that groups messages and people
+    for usability purposes. E.g. 'Candidates running for president'"""
+    name = models.CharField(max_length=255)
+    description = models.CharField(max_length=512, blank=True)
+    slug = AutoSlugField(populate_from='name', unique=True)
+    persons = models.ManyToManyField(Person,
+        related_name='writeit_instances',
+        through='Membership')
+    owner = models.ForeignKey(User, related_name="writeitinstances")
+
+    def add_person(self, person):
+        Membership.objects.get_or_create(writeitinstance=self, person=person)
+
+    @property
+    def persons_with_contacts(self):
+        return self.persons.filter(contact__writeitinstance=self, contact__isnull=False).distinct()
+
+    def relate_with_persons_from_popit_api_instance(self, popit_api_instance):
+        try:
+            popit_api_instance.fetch_all_from_api(writeitinstance=self)
+        except ConnectionError, e:
+            self.do_something_with_a_vanished_popit_api_instance(popit_api_instance)
+            e.message = _('We could not connect with the URL')
+            return (False, e)
+        except Exception, e:
+            self.do_something_with_a_vanished_popit_api_instance(popit_api_instance)
+            return (False, e)
+        persons = Person.objects.filter(api_instance=popit_api_instance)
+        for person in persons:
+            # There could be several memberships created.
+            memberships = Membership.objects.filter(writeitinstance=self, person=person)
+            if memberships.count() == 0:
+                Membership.objects.create(writeitinstance=self, person=person)
+            if memberships.count() > 1:
+                membership = memberships[0]
+                memberships.exclude(id=membership.id).delete()
+
+        return (True, None)
+
+    def do_something_with_a_vanished_popit_api_instance(self, popit_api_instance):
+        pass
+
+    def _load_persons_from_a_popit_api(self, popit_api_instance):
+        success_relating_people, error = self.relate_with_persons_from_popit_api_instance(popit_api_instance)
+        record = WriteitInstancePopitInstanceRecord.objects.get(
+            writeitinstance=self,
+            popitapiinstance=popit_api_instance
+            )
+        if success_relating_people:
+            record.set_status('success')
+        else:
+            if isinstance(error, ConnectionError):
+                record.set_status('error', _('We could not connect with the URL'))
+            else:
+                record.set_status('error', error.message)
+        return (success_relating_people, error)
+
+    def load_persons_from_a_popit_api(self, popit_url):
+        '''This is an async wrapper for getting people from the api'''
+        popit_api_instance, created = PopitApiInstance.objects.get_or_create(url=popit_url)
+        record, created = WriteitInstancePopitInstanceRecord.objects.get_or_create(
+            writeitinstance=self,
+            popitapiinstance=popit_api_instance
+            )
+        if not created:
+            record.updated = datetime.datetime.today()
+            record.save()
+        record.set_status('inprogress')
+        from nuntium.tasks import pull_from_popit
+        return pull_from_popit.delay(self, popit_api_instance)
+
+    def get_absolute_url(self):
+        return reverse('instance_detail', subdomain=self.slug)
+
+    @property
+    def pulling_from_popit_status(self):
+        records = WriteitInstancePopitInstanceRecord.objects.filter(writeitinstance=self)
+        result = {'nothing': 0, 'inprogress': 0, 'success': 0, 'error': 0}
+        for record in records:
+            result[record.status] += 1
+        return result
+
+    @property
+    def can_create_messages(self):
+        if self.config.allow_messages_using_form and \
+                self.contacts.exists():
+            return True
+
+        return False
+
+    def __unicode__(self):
+        return self.name
+
+
+class Membership(models.Model):
+    person = models.ForeignKey(Person)
+    writeitinstance = models.ForeignKey(WriteItInstance)
+
+
+def new_write_it_instance(sender, instance, created, **kwargs):
+    from nuntium.models import (
+        NewAnswerNotificationTemplate, ConfirmationTemplate)
+    if created:
+        NewAnswerNotificationTemplate.objects.create(
+            writeitinstance=instance
+            )
+        ConfirmationTemplate.objects.create(
+            writeitinstance=instance
+        )
+
+post_save.connect(new_write_it_instance, sender=WriteItInstance)
+
+
+PERIODICITY = (
+    ('--', 'Never'),
+    ('2D', 'Twice every Day'),
+    ('1D', 'Daily'),
+    ('1W', 'Weekly'),
+)
+
+
+class WriteitInstancePopitInstanceRecord(models.Model):
+    STATUS_CHOICES = (
+        ("nothing", _("Not doing anything now")),
+        ("error", _("Error")),
+        ("success", _("Success")),
+        ("waiting", _("Waiting")),
+        ("inprogress", _("In Progress")),
+        )
+    writeitinstance = models.ForeignKey(WriteItInstance)
+    popitapiinstance = models.ForeignKey(ApiInstance)
+    periodicity = models.CharField(
+        max_length="2",
+        choices=PERIODICITY,
+        default='1W',
+        )
+    status = models.CharField(
+        max_length="20",
+        choices=STATUS_CHOICES,
+        default="nothing",
+        )
+    status_explanation = models.TextField(default='')
+    updated = models.DateTimeField(auto_now_add=True)
+    created = models.DateTimeField(auto_now_add=True, editable=False)
+
+    def __unicode__(self):
+        return "The people from {url} were loaded into {instance}".format(
+            url=self.popitapiinstance.url,
+            instance=self.writeitinstance.__unicode__(),
+            )
+
+    def set_status(self, status, explanation=''):
+        self.status = status
+        self.status_explanation = explanation
+        self.save()
+
+
+class WriteItInstanceConfig(models.Model):
+    writeitinstance = AutoOneToOneField(WriteItInstance, related_name='config')
+    testing_mode = models.BooleanField(default=True)
+    moderation_needed_in_all_messages = models.BooleanField(
+        help_text=_("Every message is going to \
+        have a moderation mail"), default=False)
+    allow_messages_using_form = models.BooleanField(
+        help_text=_("Allow the creation of new messages \
+        using the web"), default=True)
+    rate_limiter = models.IntegerField(default=0)
+    notify_owner_when_new_answer = models.BooleanField(
+        help_text=_("The owner of this instance \
+        should be notified \
+        when a new answer comes in"), default=False)
+    autoconfirm_api_messages = models.BooleanField(
+        help_text=_("Messages pushed to the api should \
+            be confirmed automatically"), default=True)
+
+    custom_from_domain = models.CharField(max_length=512, null=True, blank=True)
+    email_host = models.CharField(max_length=512, null=True, blank=True)
+    email_host_password = models.CharField(max_length=512, null=True, blank=True)
+    email_host_user = models.CharField(max_length=512, null=True, blank=True)
+    email_port = models.IntegerField(null=True, blank=True)
+    email_use_tls = models.NullBooleanField()
+    email_use_ssl = models.NullBooleanField()
+    can_create_answer = models.BooleanField(default=False, help_text="Can create an answer using the WebUI")
+    maximum_recipients = models.PositiveIntegerField(default=5)
+    default_language = models.CharField(max_length=10, choices=settings.LANGUAGES)
+
+    def get_mail_connection(self):
+        connection = mail.get_connection()
+        if self.custom_from_domain:
+            connection.host = self.email_host
+            connection.password = self.email_host_password
+            connection.username = self.email_host_user
+            connection.port = self.email_port
+            connection.use_tls = self.email_use_tls
+        return connection

--- a/mailit/migrations/0012_move_to_instance.py
+++ b/mailit/migrations/0012_move_to_instance.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'RawIncomingEmail.writeitinstance'
+        db.alter_column(u'mailit_rawincomingemail', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(null=True, to=orm['instance.WriteItInstance']))
+
+        # Changing field 'MailItTemplate.writeitinstance'
+        db.alter_column(u'mailit_mailittemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(unique=True, to=orm['instance.WriteItInstance']))
+
+    def backwards(self, orm):
+
+        # Changing field 'RawIncomingEmail.writeitinstance'
+        db.alter_column(u'mailit_rawincomingemail', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(null=True, to=orm['nuntium.WriteItInstance']))
+
+        # Changing field 'MailItTemplate.writeitinstance'
+        db.alter_column(u'mailit_mailittemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(unique=True, to=orm['nuntium.WriteItInstance']))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'instance.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'instance.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['instance.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'mailit.bouncedmessagerecord': {
+            'Meta': {'object_name': 'BouncedMessageRecord'},
+            'bounce_text': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'mailit.mailittemplate': {
+            'Meta': {'object_name': 'MailItTemplate'},
+            'content_html_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_template': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'default': "'{subject}'", 'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'mailit_template'", 'unique': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'mailit.rawincomingemail': {
+            'Meta': {'object_name': 'RawIncomingEmail'},
+            'answer': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'raw_email'", 'unique': 'True', 'null': 'True', 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2048'}),
+            'problem': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'raw_emails'", 'null': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['mailit']

--- a/mailit/models.py
+++ b/mailit/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models.signals import post_save
-from nuntium.models import WriteItInstance, OutboundMessage, Answer, read_template_as_string
+from instance.models import WriteItInstance
+from nuntium.models import OutboundMessage, Answer, read_template_as_string
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -12,7 +12,8 @@ from django.test.utils import override_settings
 from django.utils.translation import activate
 
 from contactos.models import Contact, ContactType
-from nuntium.models import Message, WriteItInstance, OutboundMessage
+from instance.models import WriteItInstance
+from nuntium.models import Message, OutboundMessage
 from nuntium.plugins import OutputPlugin
 from nuntium.user_section.tests.user_section_views_tests import UserSectionTestCase
 

--- a/mailit/tests/save_raw_email_tests.py
+++ b/mailit/tests/save_raw_email_tests.py
@@ -2,7 +2,8 @@
 from global_test_case import GlobalTestCase as TestCase
 from mailit.models import RawIncomingEmail
 from ..bin.handleemail import EmailHandler
-from nuntium.models import WriteItInstance, Answer, OutboundMessage
+from instance.models import WriteItInstance
+from nuntium.models import Answer, OutboundMessage
 from ..bin import config
 from django.contrib.auth.models import User
 from mailit.bin.handleemail import EmailAnswer

--- a/mailit/views.py
+++ b/mailit/views.py
@@ -4,7 +4,7 @@ from .forms import MailitTemplateForm
 from subdomains.utils import reverse
 from django.shortcuts import get_object_or_404
 from django.http import Http404
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 

--- a/nuntium/admin.py
+++ b/nuntium/admin.py
@@ -1,8 +1,10 @@
 from django.contrib import admin
-from .models import Message, WriteItInstance, OutboundMessage, MessageRecord, \
+from instance.models import WriteItInstanceConfig
+from .models import Message, OutboundMessage, MessageRecord, \
     Answer, AnswerWebHook, NewAnswerNotificationTemplate, \
-    ConfirmationTemplate, WriteItInstanceConfig
+    ConfirmationTemplate
 
+from instance.models import WriteItInstance
 from popit.models import ApiInstance, Person
 from mailit.models import MailItTemplate
 from django_object_actions import DjangoObjectActions

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from tastypie.resources import ModelResource, ALL_WITH_RELATIONS, Resource
-from .models import WriteItInstance, Message, Answer, \
+from instance.models import WriteItInstance
+from .models import Message, Answer, \
     OutboundMessageIdentifier, OutboundMessage, Confirmation
 from tastypie.authentication import ApiKeyAuthentication
 from tastypie.authorization import Authorization

--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -2,7 +2,8 @@
 import urlparse
 
 from django.forms import ModelForm, ModelMultipleChoiceField, SelectMultiple, URLField, Form, Textarea, TextInput, EmailInput
-from .models import Message, WriteItInstance, Confirmation
+from instance.models import WriteItInstance
+from .models import Message, Confirmation
 
 from contactos.models import Contact
 from django.forms import ValidationError

--- a/nuntium/management/commands/back_fill_writeit_popit_records.py
+++ b/nuntium/management/commands/back_fill_writeit_popit_records.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from popit.models import ApiInstance
-from ...models import WriteitInstancePopitInstanceRecord
+from instance.models import WriteitInstancePopitInstanceRecord
 from django.contrib.auth.models import User
 import logging
 

--- a/nuntium/middleware.py
+++ b/nuntium/middleware.py
@@ -4,7 +4,7 @@ from django.middleware.locale import LocaleMiddleware
 from django.utils import translation
 from django.conf import settings
 
-from nuntium.models import WriteItInstanceConfig
+from instance.models import WriteItInstanceConfig
 
 
 def get_language_from_request(request, check_path=False):

--- a/nuntium/migrations/0067_move_to_instance.py
+++ b/nuntium/migrations/0067_move_to_instance.py
@@ -1,0 +1,294 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    depends_on = (
+        ('instance', '0001_move_to_instance'),
+    )
+
+    def forwards(self, orm):
+        # Changing field 'RateLimiter.writeitinstance'
+        db.alter_column(u'nuntium_ratelimiter', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['instance.WriteItInstance']))
+
+        # Changing field 'NewAnswerNotificationTemplate.writeitinstance'
+        db.alter_column(u'nuntium_newanswernotificationtemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(unique=True, to=orm['instance.WriteItInstance']))
+
+        # Changing field 'ConfirmationTemplate.writeitinstance'
+        db.alter_column(u'nuntium_confirmationtemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['instance.WriteItInstance'], unique=True))
+
+        # Changing field 'AnswerWebHook.writeitinstance'
+        db.alter_column(u'nuntium_answerwebhook', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['instance.WriteItInstance']))
+
+        # Changing field 'Message.writeitinstance'
+        db.alter_column(u'nuntium_message', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['instance.WriteItInstance']))
+
+    def backwards(self, orm):
+        db.rename_table('instance_writeitinstance', 'nuntium_writeitinstance')
+        db.rename_table('instance_membership', 'nuntium_membership')
+        db.rename_table('instance_writeitinstancepopitinstancerecord', 'nuntium_writeitinstancepopitinstancerecord')
+        db.rename_table('instance_writeitinstanceconfig', 'nuntium_writeitinstanceconfig')
+
+        if not db.dry_run:
+            # For permissions to work properly after migrating
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='instance',
+                model__in=(
+                    'writeitinstance',
+                    'membership',
+                    'writeitinstancepopitinstancerecord',
+                    'writeitinstanceconfig',
+                )
+            ).update(app_label='nuntium')
+
+        # Changing field 'RateLimiter.writeitinstance'
+        db.alter_column(u'nuntium_ratelimiter', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['nuntium.WriteItInstance']))
+
+        # Changing field 'NewAnswerNotificationTemplate.writeitinstance'
+        db.alter_column(u'nuntium_newanswernotificationtemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(unique=True, to=orm['nuntium.WriteItInstance']))
+
+        # Changing field 'ConfirmationTemplate.writeitinstance'
+        db.alter_column(u'nuntium_confirmationtemplate', 'writeitinstance_id', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['nuntium.WriteItInstance'], unique=True))
+
+        # Changing field 'AnswerWebHook.writeitinstance'
+        db.alter_column(u'nuntium_answerwebhook', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['nuntium.WriteItInstance']))
+
+        # Changing field 'Message.writeitinstance'
+        db.alter_column(u'nuntium_message', 'writeitinstance_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['nuntium.WriteItInstance']))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contactos.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.ContactType']"}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_bounced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'popit_identifier': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'null': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'contactos.contacttype': {
+            'Meta': {'object_name': 'ContactType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangoplugins.plugin': {
+            'Meta': {'ordering': "(u'_order',)", 'unique_together': "(('point', 'name'),)", 'object_name': 'Plugin'},
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.PluginPoint']"}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'djangoplugins.pluginpoint': {
+            'Meta': {'object_name': 'PluginPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pythonpath': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'instance.membership': {
+            'Meta': {'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'instance.writeitinstance': {
+            'Meta': {'object_name': 'WriteItInstance'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'writeitinstances'", 'to': u"orm['auth.User']"}),
+            'persons': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'writeit_instances'", 'symmetrical': 'False', 'through': u"orm['instance.Membership']", 'to': u"orm['popit.Person']"}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'})
+        },
+        u'nuntium.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_html': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"})
+        },
+        u'nuntium.answerattachment': {
+            'Meta': {'object_name': 'AnswerAttachment'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'to': u"orm['nuntium.Answer']"}),
+            'content': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'})
+        },
+        u'nuntium.answerwebhook': {
+            'Meta': {'object_name': 'AnswerWebHook'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answer_webhooks'", 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.confirmation': {
+            'Meta': {'object_name': 'Confirmation'},
+            'confirmated_at': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2016, 7, 6, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.Message']", 'unique': 'True'})
+        },
+        u'nuntium.confirmationtemplate': {
+            'Meta': {'object_name': 'ConfirmationTemplate'},
+            'content_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'content_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '512', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['instance.WriteItInstance']", 'unique': 'True'})
+        },
+        u'nuntium.message': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Message'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'author_name': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'confirmated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderated': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.messagerecord': {
+            'Meta': {'object_name': 'MessageRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'datetime': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2016, 7, 6, 0, 0)'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'nuntium.moderation': {
+            'Meta': {'object_name': 'Moderation'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'moderation'", 'unique': 'True', 'to': u"orm['nuntium.Message']"})
+        },
+        u'nuntium.newanswernotificationtemplate': {
+            'Meta': {'object_name': 'NewAnswerNotificationTemplate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject_template': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'template_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'template_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'new_answer_notification_template'", 'unique': 'True', 'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.nocontactom': {
+            'Meta': {'object_name': 'NoContactOM'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.Person']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessage': {
+            'Meta': {'object_name': 'OutboundMessage'},
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contactos.Contact']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.Message']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'new'", 'max_length': "'10'"})
+        },
+        u'nuntium.outboundmessageidentifier': {
+            'Meta': {'object_name': 'OutboundMessageIdentifier'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'outbound_message': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['nuntium.OutboundMessage']", 'unique': 'True'})
+        },
+        u'nuntium.outboundmessagepluginrecord': {
+            'Meta': {'object_name': 'OutboundMessagePluginRecord'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number_of_attempts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'outbound_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['nuntium.OutboundMessage']"}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djangoplugins.Plugin']"}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'try_again': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'nuntium.ratelimiter': {
+            'Meta': {'object_name': 'RateLimiter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'day': ('django.db.models.fields.DateField', [], {}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'writeitinstance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['instance.WriteItInstance']"})
+        },
+        u'nuntium.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscribers'", 'to': u"orm['nuntium.Message']"})
+        },
+        u'popit.apiinstance': {
+            'Meta': {'object_name': 'ApiInstance'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('popit.fields.ApiInstanceURLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        u'popit.person': {
+            'Meta': {'object_name': 'Person'},
+            'api_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['popit.ApiInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'popit_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'popit_url': ('popit.fields.PopItURLField', [], {'default': "''", 'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['nuntium']

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -1,15 +1,15 @@
 import textwrap
 
+from django.contrib.auth.models import User
 from django.db.models.signals import post_save, pre_save
 from django.db import models
 from django.utils.translation import override, ugettext_lazy as _
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
-from popit.models import Person, ApiInstance
+from popit.models import Person
 from contactos.models import Contact
 from .plugins import OutputPlugin
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
-from django.contrib.auth.models import User
 import datetime
 from djangoplugins.models import Plugin
 from django.core.mail import EmailMultiAlternatives
@@ -23,18 +23,13 @@ import requests
 from django.utils.timezone import now
 from django.contrib.sites.models import Site
 
-from annoying.fields import AutoOneToOneField
-
-from autoslug import AutoSlugField
 from unidecode import unidecode
 from django.db.models.query import QuerySet
 from itertools import chain
 import os
 import codecs
-from popit_api_instance import PopitApiInstance
-from requests.exceptions import ConnectionError
-from django.core import mail
 
+from instance.models import WriteItInstance
 from writeit_utils import escape_dictionary_values
 
 
@@ -51,159 +46,6 @@ def template_with_wrap(template, context):
     return u'\n'.join(
         [wrapper.fill(x) for x in template.format(**context).splitlines()]
         )
-
-
-class WriteItInstance(models.Model):
-    """WriteItInstance: Entity that groups messages and people
-    for usability purposes. E.g. 'Candidates running for president'"""
-    name = models.CharField(max_length=255)
-    description = models.CharField(max_length=512, blank=True)
-    slug = AutoSlugField(populate_from='name', unique=True)
-    persons = models.ManyToManyField(Person,
-        related_name='writeit_instances',
-        through='Membership')
-    owner = models.ForeignKey(User, related_name="writeitinstances")
-
-    def add_person(self, person):
-        Membership.objects.get_or_create(writeitinstance=self, person=person)
-
-    @property
-    def persons_with_contacts(self):
-        return self.persons.filter(contact__writeitinstance=self, contact__isnull=False).distinct()
-
-    def relate_with_persons_from_popit_api_instance(self, popit_api_instance):
-        try:
-            popit_api_instance.fetch_all_from_api(writeitinstance=self)
-        except ConnectionError, e:
-            self.do_something_with_a_vanished_popit_api_instance(popit_api_instance)
-            e.message = _('We could not connect with the URL')
-            return (False, e)
-        except Exception, e:
-            self.do_something_with_a_vanished_popit_api_instance(popit_api_instance)
-            return (False, e)
-        persons = Person.objects.filter(api_instance=popit_api_instance)
-        for person in persons:
-            # There could be several memberships created.
-            memberships = Membership.objects.filter(writeitinstance=self, person=person)
-            if memberships.count() == 0:
-                Membership.objects.create(writeitinstance=self, person=person)
-            if memberships.count() > 1:
-                membership = memberships[0]
-                memberships.exclude(id=membership.id).delete()
-
-        return (True, None)
-
-    def do_something_with_a_vanished_popit_api_instance(self, popit_api_instance):
-        pass
-
-    def _load_persons_from_a_popit_api(self, popit_api_instance):
-        success_relating_people, error = self.relate_with_persons_from_popit_api_instance(popit_api_instance)
-        record = WriteitInstancePopitInstanceRecord.objects.get(
-            writeitinstance=self,
-            popitapiinstance=popit_api_instance
-            )
-        if success_relating_people:
-            record.set_status('success')
-        else:
-            if isinstance(error, ConnectionError):
-                record.set_status('error', _('We could not connect with the URL'))
-            else:
-                record.set_status('error', error.message)
-        return (success_relating_people, error)
-
-    def load_persons_from_a_popit_api(self, popit_url):
-        '''This is an async wrapper for getting people from the api'''
-        popit_api_instance, created = PopitApiInstance.objects.get_or_create(url=popit_url)
-        record, created = WriteitInstancePopitInstanceRecord.objects.get_or_create(
-            writeitinstance=self,
-            popitapiinstance=popit_api_instance
-            )
-        if not created:
-            record.updated = datetime.datetime.today()
-            record.save()
-        record.set_status('inprogress')
-        from nuntium.tasks import pull_from_popit
-        return pull_from_popit.delay(self, popit_api_instance)
-
-    def get_absolute_url(self):
-        return reverse('instance_detail', subdomain=self.slug)
-
-    @property
-    def pulling_from_popit_status(self):
-        records = WriteitInstancePopitInstanceRecord.objects.filter(writeitinstance=self)
-        result = {'nothing': 0, 'inprogress': 0, 'success': 0, 'error': 0}
-        for record in records:
-            result[record.status] += 1
-        return result
-
-    @property
-    def can_create_messages(self):
-        if self.config.allow_messages_using_form and \
-                self.contacts.exists():
-            return True
-
-        return False
-
-    def __unicode__(self):
-        return self.name
-
-
-
-def new_write_it_instance(sender, instance, created, **kwargs):
-    if created:
-        NewAnswerNotificationTemplate.objects.create(
-            writeitinstance=instance
-            )
-        ConfirmationTemplate.objects.create(
-            writeitinstance=instance
-        )
-
-post_save.connect(new_write_it_instance, sender=WriteItInstance)
-
-
-class WriteItInstanceConfig(models.Model):
-    writeitinstance = AutoOneToOneField(WriteItInstance, related_name='config')
-    testing_mode = models.BooleanField(default=True)
-    moderation_needed_in_all_messages = models.BooleanField(
-        help_text=_("Every message is going to \
-        have a moderation mail"), default=False)
-    allow_messages_using_form = models.BooleanField(
-        help_text=_("Allow the creation of new messages \
-        using the web"), default=True)
-    rate_limiter = models.IntegerField(default=0)
-    notify_owner_when_new_answer = models.BooleanField(
-        help_text=_("The owner of this instance \
-        should be notified \
-        when a new answer comes in"), default=False)
-    autoconfirm_api_messages = models.BooleanField(
-        help_text=_("Messages pushed to the api should \
-            be confirmed automatically"), default=True)
-
-    custom_from_domain = models.CharField(max_length=512, null=True, blank=True)
-    email_host = models.CharField(max_length=512, null=True, blank=True)
-    email_host_password = models.CharField(max_length=512, null=True, blank=True)
-    email_host_user = models.CharField(max_length=512, null=True, blank=True)
-    email_port = models.IntegerField(null=True, blank=True)
-    email_use_tls = models.NullBooleanField()
-    email_use_ssl = models.NullBooleanField()
-    can_create_answer = models.BooleanField(default=False, help_text="Can create an answer using the WebUI")
-    maximum_recipients = models.PositiveIntegerField(default=5)
-    default_language = models.CharField(max_length=10, choices=settings.LANGUAGES)
-
-    def get_mail_connection(self):
-        connection = mail.get_connection()
-        if self.custom_from_domain:
-            connection.host = self.email_host
-            connection.password = self.email_host_password
-            connection.username = self.email_host_user
-            connection.port = self.email_port
-            connection.use_tls = self.email_use_tls
-        return connection
-
-
-class Membership(models.Model):
-    person = models.ForeignKey(Person)
-    writeitinstance = models.ForeignKey(WriteItInstance)
 
 
 class MessageRecord(models.Model):
@@ -953,46 +795,3 @@ post_save.connect(rate_limiting, sender=Message)
 from tastypie.models import create_api_key
 
 models.signals.post_save.connect(create_api_key, sender=User)
-
-PERIODICITY = (
-    ('--', 'Never'),
-    ('2D', 'Twice every Day'),
-    ('1D', 'Daily'),
-    ('1W', 'Weekly'),
-)
-
-
-class WriteitInstancePopitInstanceRecord(models.Model):
-    STATUS_CHOICES = (
-        ("nothing", _("Not doing anything now")),
-        ("error", _("Error")),
-        ("success", _("Success")),
-        ("waiting", _("Waiting")),
-        ("inprogress", _("In Progress")),
-        )
-    writeitinstance = models.ForeignKey(WriteItInstance)
-    popitapiinstance = models.ForeignKey(ApiInstance)
-    periodicity = models.CharField(
-        max_length="2",
-        choices=PERIODICITY,
-        default='1W',
-        )
-    status = models.CharField(
-        max_length="20",
-        choices=STATUS_CHOICES,
-        default="nothing",
-        )
-    status_explanation = models.TextField(default='')
-    updated = models.DateTimeField(auto_now_add=True)
-    created = models.DateTimeField(auto_now_add=True, editable=False)
-
-    def __unicode__(self):
-        return "The people from {url} were loaded into {instance}".format(
-            url=self.popitapiinstance.url,
-            instance=self.writeitinstance.__unicode__(),
-            )
-
-    def set_status(self, status, explanation=''):
-        self.status = status
-        self.status_explanation = explanation
-        self.save()

--- a/nuntium/tasks.py
+++ b/nuntium/tasks.py
@@ -1,6 +1,6 @@
 from celery import task
 from .management.commands.send_mails import send_mails
-from nuntium.models import WriteitInstancePopitInstanceRecord
+from instance.models import WriteitInstancePopitInstanceRecord
 from nuntium.popit_api_instance import PopitApiInstance
 import logging
 

--- a/nuntium/tests/all_messages_with_moderation_test.py
+++ b/nuntium/tests/all_messages_with_moderation_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance, Moderation
+from instance.models import WriteItInstance
+from ..models import Message, Moderation
 from popit.models import Person
 from django.core import mail
 

--- a/nuntium/tests/api/answer_resource_test.py
+++ b/nuntium/tests/api/answer_resource_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from ...models import WriteItInstance
+from instance.models import WriteItInstance
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
 from popit.models import Person

--- a/nuntium/tests/api/instance_resource_test.py
+++ b/nuntium/tests/api/instance_resource_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from ...models import Message, WriteItInstance, Confirmation
+from instance.models import WriteItInstance
+from ...models import Message, Confirmation
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
 from popit.models import Person

--- a/nuntium/tests/api/message_resource_test.py
+++ b/nuntium/tests/api/message_resource_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from ...models import Message, WriteItInstance, Confirmation
+from instance.models import WriteItInstance
+from ...models import Message, Confirmation
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
 from popit.models import Person

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from ...models import WriteItInstance
+from instance.models import WriteItInstance
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
 from popit.models import Person

--- a/nuntium/tests/confirmation_template_test.py
+++ b/nuntium/tests/confirmation_template_test.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
+from instance.models import WriteItInstance
 from ..models import Confirmation, send_confirmation_email
-from ..models import Message, WriteItInstance, ConfirmationTemplate
+from ..models import Message, ConfirmationTemplate
 from django.core import mail
 from subdomains.utils import reverse
 from django.contrib.auth.models import User

--- a/nuntium/tests/confirmation_test.py
+++ b/nuntium/tests/confirmation_test.py
@@ -1,6 +1,7 @@
 from global_test_case import GlobalTestCase as TestCase
+from instance.models import WriteItInstance
 from ..models import Confirmation, OutboundMessage
-from ..models import Message, WriteItInstance
+from ..models import Message
 from popit.models import Person
 from contactos.models import Contact
 from datetime import datetime

--- a/nuntium/tests/home_view_tests.py
+++ b/nuntium/tests/home_view_tests.py
@@ -1,7 +1,7 @@
 from global_test_case import GlobalTestCase as TestCase
 from subdomains.utils import reverse
 from django.utils.translation import activate
-from ..models import WriteItInstance
+from instance.models import WriteItInstance
 from django.contrib.auth.models import User
 from django.test.client import Client
 

--- a/nuntium/tests/instance_config_tests.py
+++ b/nuntium/tests/instance_config_tests.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from nuntium.models import WriteItInstance, WriteItInstanceConfig, \
-    Message, Membership
+from instance.models import Membership, WriteItInstance, WriteItInstanceConfig
+from nuntium.models import Message
 from popit.models import ApiInstance, Person
 from django.contrib.auth.models import User
 from mailit import MailChannel

--- a/nuntium/tests/message_creation_tests.py
+++ b/nuntium/tests/message_creation_tests.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from nuntium.models import WriteItInstance, Message
+from instance.models import WriteItInstance
+from nuntium.models import Message
 from subdomains.utils import reverse
 from popit.models import Person
 from nuntium.forms import WhoForm, DraftForm

--- a/nuntium/tests/message_detail_view_test.py
+++ b/nuntium/tests/message_detail_view_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance, Confirmation
+from instance.models import WriteItInstance
+from ..models import Message, Confirmation
 from popit.models import Person
 import datetime
 from nuntium.views import MessageThreadView

--- a/nuntium/tests/message_form_tests.py
+++ b/nuntium/tests/message_form_tests.py
@@ -2,7 +2,8 @@
 from global_test_case import GlobalTestCase as TestCase
 from popit.models import Person
 from contactos.models import Contact
-from ..models import Message, Confirmation, WriteItInstance, OutboundMessage, Membership
+from instance.models import Membership, WriteItInstance
+from ..models import Message, Confirmation, OutboundMessage
 from ..forms import MessageCreateForm, PersonMultipleChoiceField
 
 from django.forms import ValidationError, SelectMultiple

--- a/nuntium/tests/message_threads_tests.py
+++ b/nuntium/tests/message_threads_tests.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance, Message
+from instance.models import WriteItInstance
+from nuntium.models import Message
 
 
 class MessagesThreadsTestCase(TestCase):

--- a/nuntium/tests/messages_per_person_view_test.py
+++ b/nuntium/tests/messages_per_person_view_test.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
 from subdomains.utils import reverse
-from ..models import WriteItInstance, Message
+from instance.models import WriteItInstance
+from ..models import Message
 from popit.models import Person
 
 

--- a/nuntium/tests/messages_search_test.py
+++ b/nuntium/tests/messages_search_test.py
@@ -9,8 +9,8 @@ from haystack import indexes
 from haystack.fields import CharField
 from haystack.forms import SearchForm
 from subdomains.utils import reverse
+from instance.models import WriteItInstance
 from ..views import MessageSearchView, PerInstanceSearchView
-from ..models import WriteItInstance
 from haystack.views import SearchView
 from popit.models import Person
 import urllib

--- a/nuntium/tests/messages_test.py
+++ b/nuntium/tests/messages_test.py
@@ -5,7 +5,8 @@ from global_test_case import UsingDbMixin
 from django.db import IntegrityError
 from django.utils.translation import ugettext as _
 from contactos.models import Contact
-from ..models import Message, WriteItInstance, OutboundMessage, NoContactOM
+from instance.models import WriteItInstance
+from ..models import Message, OutboundMessage, NoContactOM
 from popit.models import Person, ApiInstance
 from subdomains.utils import reverse
 from django.contrib.auth.models import User

--- a/nuntium/tests/outbound_message_plugin_record_test.py
+++ b/nuntium/tests/outbound_message_plugin_record_test.py
@@ -1,5 +1,6 @@
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance, OutboundMessage, OutboundMessagePluginRecord
+from instance.models import WriteItInstance
+from ..models import Message, OutboundMessage, OutboundMessagePluginRecord
 from plugin_mock.mental_message_plugin import MentalMessage
 from contactos.models import Contact
 # from djangoplugins.models import Plugin

--- a/nuntium/tests/outbound_message_test.py
+++ b/nuntium/tests/outbound_message_test.py
@@ -3,7 +3,8 @@ from django.db import IntegrityError
 from django.db import models
 from django.utils.translation import ugettext as _
 from contactos.models import Contact, ContactType
-from ..models import Message, WriteItInstance, OutboundMessage, \
+from instance.models import WriteItInstance
+from ..models import Message, OutboundMessage, \
     MessageRecord, OutboundMessagePluginRecord, \
     OutboundMessageIdentifier, Answer, \
     NoContactOM, AbstractOutboundMessage

--- a/nuntium/tests/popit_api_instance_tests.py
+++ b/nuntium/tests/popit_api_instance_tests.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from mock import patch
 
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from contactos.models import Contact, ContactType
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/nuntium/tests/popit_writeit_relation_tests.py
+++ b/nuntium/tests/popit_writeit_relation_tests.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
-from ..models import WriteItInstance, Membership
-from ..models import WriteitInstancePopitInstanceRecord
+from instance.models import (
+    Membership, WriteItInstance, WriteitInstancePopitInstanceRecord)
 from popit.models import ApiInstance
 from django.utils.unittest import skip
 from django.contrib.auth.models import User

--- a/nuntium/tests/public_messages_test.py
+++ b/nuntium/tests/public_messages_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
 from global_test_case import GlobalTestCase as TestCase
-from ..models import WriteItInstance, Message, Confirmation
+from instance.models import WriteItInstance
+from ..models import Message, Confirmation
 from popit.models import Person
 from django.contrib.auth.models import User
 from tastypie.test import ResourceTestCase, TestApiClient

--- a/nuntium/tests/rate_limiter_tests.py
+++ b/nuntium/tests/rate_limiter_tests.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
 from django.contrib.auth.models import User
-from ..models import WriteItInstance, RateLimiter, Message
+from instance.models import WriteItInstance
+from ..models import RateLimiter, Message
 from datetime import date
 from django.core.exceptions import ValidationError
 from popit.models import Person

--- a/nuntium/tests/record_system_test.py
+++ b/nuntium/tests/record_system_test.py
@@ -1,5 +1,6 @@
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance, OutboundMessage, MessageRecord
+from instance.models import WriteItInstance
+from ..models import Message, OutboundMessage, MessageRecord
 from django.contrib.contenttypes.models import ContentType
 from popit.models import Person
 from django.utils.translation import ugettext as _

--- a/nuntium/tests/rtl_messages_test.py
+++ b/nuntium/tests/rtl_messages_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance
+from instance.models import WriteItInstance
+from ..models import Message
 from popit.models import Person
 
 

--- a/nuntium/tests/see_all_messages_from_a_person_tests.py
+++ b/nuntium/tests/see_all_messages_from_a_person_tests.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from nuntium.models import WriteItInstance, Message
+from instance.models import WriteItInstance
+from nuntium.models import Message
 from subdomains.utils import reverse
 
 

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -1,5 +1,6 @@
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Subscriber, Message, WriteItInstance, \
+from instance.models import WriteItInstance
+from ..models import Subscriber, Message, \
     Confirmation, Answer, NewAnswerNotificationTemplate
 from popit.models import Person
 from django.contrib.auth.models import User

--- a/nuntium/tests/tasks_test.py
+++ b/nuntium/tests/tasks_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
-from nuntium.models import OutboundMessage, WriteItInstance, WriteitInstancePopitInstanceRecord
+from instance.models import WriteItInstance, WriteitInstancePopitInstanceRecord
+from nuntium.models import OutboundMessage
 from ..tasks import send_mails_task
 from mock import patch
 from popit.models import Person

--- a/nuntium/tests/webhooks_tests.py
+++ b/nuntium/tests/webhooks_tests.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from global_test_case import GlobalTestCase as TestCase
-from ..models import Message, WriteItInstance, AnswerWebHook, Answer
+from instance.models import WriteItInstance
+from ..models import Message, AnswerWebHook, Answer
 from mock import patch
 
 

--- a/nuntium/tests/writeitinstance_newform_tests.py
+++ b/nuntium/tests/writeitinstance_newform_tests.py
@@ -62,7 +62,7 @@ class InstanceCreateFormTestCase(TestCase):
 
     def test_it_uses_popit_main_url_as_well(self):
         '''It accepts main popit url as well'''
-        with patch('nuntium.models.WriteItInstance.load_persons_from_a_popit_api') as method_load:
+        with patch('instance.models.WriteItInstance.load_persons_from_a_popit_api') as method_load:
             data = {
                 'owner': self.user.id,
                 'popit_url': 'https://kenyan-politicians.popit.mysociety.org/',

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -2,7 +2,8 @@
 from urlparse import urlsplit, urlunsplit
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance, Message, Membership, Confirmation
+from instance.models import Membership, WriteItInstance
+from nuntium.models import Message, Confirmation
 from popit.models import ApiInstance, Person
 from django.utils.unittest import skip
 from django.contrib.auth.models import User

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -22,13 +22,15 @@ from django.utils.translation import ugettext as _
 
 from popit.models import Person
 
+from instance.models import (
+    WriteItInstance,
+    WriteItInstanceConfig,
+    WriteitInstancePopitInstanceRecord,
+)
 from nuntium.models import (
     Answer,
     ConfirmationTemplate,
     NewAnswerNotificationTemplate,
-    WriteItInstance,
-    WriteItInstanceConfig,
-    WriteitInstancePopitInstanceRecord,
     AnswerWebHook,
     default_confirmation_template_content_text,
     default_confirmation_template_subject,

--- a/nuntium/user_section/tests/delete_an_instance_tests.py
+++ b/nuntium/user_section/tests/delete_an_instance_tests.py
@@ -1,5 +1,5 @@
 from subdomains.utils import reverse
-from ...models import WriteItInstance
+from instance.models import WriteItInstance
 from .user_section_views_tests import UserSectionTestCase
 from nuntium.user_section.views import WriteItDeleteView
 

--- a/nuntium/user_section/tests/documentation_tests.py
+++ b/nuntium/user_section/tests/documentation_tests.py
@@ -1,6 +1,6 @@
 from global_test_case import GlobalTestCase as TestCase
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 
 
 class DocumentationTestCase(TestCase):

--- a/nuntium/user_section/tests/manually_create_answers_tests.py
+++ b/nuntium/user_section/tests/manually_create_answers_tests.py
@@ -1,5 +1,6 @@
 from subdomains.utils import reverse
-from ...models import WriteItInstance, Message, Answer
+from instance.models import WriteItInstance
+from ...models import Message, Answer
 from django.contrib.auth.models import User
 from ..forms import AnswerForm
 from popit.models import Person

--- a/nuntium/user_section/tests/popit_instance_update_tests.py
+++ b/nuntium/user_section/tests/popit_instance_update_tests.py
@@ -1,6 +1,7 @@
 from global_test_case import popit_load_data
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance, Membership, WriteitInstancePopitInstanceRecord
+from instance.models import (
+    Membership, WriteItInstance, WriteitInstancePopitInstanceRecord)
 from django.contrib.auth.models import User
 from django.forms import Form, URLField
 from django.conf import settings

--- a/nuntium/user_section/tests/stats_page_tests.py
+++ b/nuntium/user_section/tests/stats_page_tests.py
@@ -1,5 +1,5 @@
 from global_test_case import GlobalTestCase as TestCase
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from subdomains.utils import reverse
 from nuntium.user_section.stats import StatsPerInstance
 

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -6,7 +6,7 @@ from popit.models import Person
 from mailit.forms import MailitTemplateForm
 from global_test_case import GlobalTestCase as TestCase, popit_load_data
 
-from nuntium.models import WriteItInstance, WriteitInstancePopitInstanceRecord
+from instance.models import WriteItInstance, WriteitInstancePopitInstanceRecord
 from nuntium.user_section.views import WriteItInstanceUpdateView, WriteItInstanceApiDocsView
 from nuntium.user_section.forms import WriteItInstanceBasicForm, \
     WriteItInstanceCreateForm, \

--- a/nuntium/user_section/tests/webhooks_maintainer_tests.py
+++ b/nuntium/user_section/tests/webhooks_maintainer_tests.py
@@ -1,5 +1,5 @@
 from subdomains.utils import reverse
-from nuntium.models import WriteItInstance
+from instance.models import WriteItInstance
 from nuntium.user_section.forms import WebhookCreateForm
 from nuntium.models import AnswerWebHook
 from django.contrib.auth.models import User

--- a/nuntium/user_section/views.py
+++ b/nuntium/user_section/views.py
@@ -10,9 +10,10 @@ from django.views.generic.edit import UpdateView, DeleteView, FormView
 
 from mailit.forms import MailitTemplateForm
 
-from ..models import WriteItInstance, Message,\
+from instance.models import WriteItInstance, WriteItInstanceConfig, WriteitInstancePopitInstanceRecord
+from ..models import Message,\
     NewAnswerNotificationTemplate, ConfirmationTemplate, \
-    Answer, WriteItInstanceConfig, WriteitInstancePopitInstanceRecord, Moderation, \
+    Answer, Moderation, \
     AnswerWebHook
 from .forms import WriteItInstanceBasicForm, \
     NewAnswerNotificationTemplateForm, ConfirmationTemplateForm, \

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -10,7 +10,8 @@ from haystack.views import SearchView
 from itertools import chain
 from popit.models import Person
 from django.db.models import Q
-from .models import WriteItInstance, Confirmation, Message, Moderation
+from instance.models import WriteItInstance
+from .models import Confirmation, Message, Moderation
 from .forms import MessageSearchForm, PerInstanceSearchForm
 
 from nuntium import forms

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -203,6 +203,7 @@ INSTALLED_APPS = (
     'annoying',
     'celery_haystack',
 
+    'instance',
     'nuntium',
     'djangoplugins',
     'pagination',


### PR DESCRIPTION
There was an unnecessary circular dependency between the 'nuntium' and
'contactos' Django apps:
    
   contactos.Contact needs nuntium (for nuntium.WriteItInstance)
   nuntium.OutboundMessage needs contactos (for contactos.Contact)
    
This wouldn't be a big deal, except that when we're migrating to Django
1.7 it means that makemigrations generates multiple initial migrations
(0001_initial and 0002_auto..., the latter of which adds the problematic
foreign keys). The second of these migrations didn't work properly on
Django 1.7 and SQLite, so the easiest way to deal with that upgrade
seems to be to:
    
 * Remove the circular dependencies with South migrations and
   Django 1.6
 * Then do the upgrade to Django 1.7, when we should now be able
   to have single initial migrations
    
This pull request deals with the first of those by creating a new
'instance' app, which contains:
    
  WriteItInstance
  Membership
  WriteItInstanceConfig
  WriteitInstancePopitInstanceRecord
