### PR TITLE
WIP Add a custom_stylesheet template tag to load instance css

### DIFF
--- a/nuntium/templates/base_instance.html
+++ b/nuntium/templates/base_instance.html
@@ -4,9 +4,11 @@
 {% load pipeline %}
 {% load i18n %}
 {% load subdomainurls %}
+{% load nuntium_tags %}
 
 {% block css %}
     {% stylesheet 'writeit-instance' %}
+    {% custom_stylesheet %}
 {% endblock css %}
 
 {% block header %}

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -1,6 +1,9 @@
 import os
+import re
 from django import template
 from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.staticfiles import finders
 from contactos.models import Contact
 from django.db.models import Q
@@ -47,6 +50,12 @@ def custom_stylesheet(context):
         subdomain = context['request'].subdomain
     except AttributeError:
         return output
+
+    if not subdomain:
+        return output
+
+    if re.search(r'[^_a-zA-Z0-9\-]', subdomain):
+        raise SuspiciousOperation(_('Invalid subdomain for custom CSS'))
 
     path = os.path.join(subdomain, 'css/custom.css')
     file_path = finders.find(path)

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -43,10 +43,15 @@ def assignment_url_with_subdomain(context, view, subdomain=UNSET, *args, **kwarg
 @register.simple_tag(takes_context=True)
 def custom_stylesheet(context):
     output = ''
-    if hasattr(context['request'], 'subdomain') and context['request'].subdomain is not None:
-        path = os.path.join(context['request'].subdomain, 'css/custom.css')
-        file_path = finders.find(path)
-        if file_path is not None:
-            path = os.path.join(settings.STATIC_URL, path)
-            output = '<link rel="stylesheet" href="{0}" type="text/css" media="screen" />'.format(path)
+    try:
+        subdomain = context['request'].subdomain
+    except AttributeError:
+        return output
+
+    path = os.path.join(subdomain, 'css/custom.css')
+    file_path = finders.find(path)
+    if file_path is not None:
+        path = os.path.join(settings.STATIC_URL, path)
+        output = '<link rel="stylesheet" href="{0}" type="text/css" media="screen" />'.format(path)
+
     return output

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -1,4 +1,7 @@
+import os
 from django import template
+from django.conf import settings
+from django.contrib.staticfiles import finders
 from contactos.models import Contact
 from django.db.models import Q
 from subdomains.templatetags.subdomainurls import url as subdomainsurls, UNSET
@@ -35,3 +38,15 @@ def join_with_commas(obj_list):
 @register.assignment_tag(takes_context=True)
 def assignment_url_with_subdomain(context, view, subdomain=UNSET, *args, **kwargs):
     return subdomainsurls(context, view, subdomain, *args, **kwargs)
+
+
+@register.simple_tag(takes_context=True)
+def custom_stylesheet(context):
+    output = ''
+    if hasattr(context['request'], 'subdomain') and context['request'].subdomain is not None:
+        path = os.path.join(context['request'].subdomain, 'css/custom.css')
+        file_path = finders.find(path)
+        if file_path is not None:
+            path = os.path.join(settings.STATIC_URL, path)
+            output = '<link rel="stylesheet" href="{0}" type="text/css" media="screen" />'.format(path)
+    return output

--- a/nuntium/tests/writeitinstances_test.py
+++ b/nuntium/tests/writeitinstances_test.py
@@ -10,8 +10,9 @@ from django.contrib.auth.models import User
 from django.utils.translation import activate
 from django.utils.translation import ugettext as _
 from django.conf import settings
-from mock import patch
+from mock import patch, Mock
 from nuntium.popit_api_instance import PopitApiInstance
+from nuntium.templatetags.nuntium_tags import custom_stylesheet
 from requests.exceptions import ConnectionError
 from contactos.models import Contact, ContactType
 
@@ -451,3 +452,17 @@ class InstanceDetailView(TestCase):
         response = self.client.get(url)
 
         self.assertIn('There is no-one to write to yet', response.content)
+
+    def test_custom_css(self):
+        self.assertEquals(
+            custom_stylesheet({'request': Mock(subdomain='example-domain')}),
+            '<link rel="stylesheet" href="/static/example-domain/css/custom.css" type="text/css" media="screen" />'
+        )
+        self.assertEquals(
+            custom_stylesheet({'request': Mock(subdomain='domain-with-no-custom-css')}),
+            ''
+        )
+        self.assertEquals(
+            custom_stylesheet({'request': Mock(subdomain=None)}),
+            ''
+        )

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -88,8 +88,11 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
 
+INSTANCE_STATIC = os.path.abspath(os.path.join(BASE_DIR, '..', 'static'))
+
 # Additional locations of static files
 STATICFILES_DIRS = (
+    INSTANCE_STATIC,
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -88,11 +88,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
 
-INSTANCE_STATIC = os.path.abspath(os.path.join(BASE_DIR, '..', 'static'))
-
 # Additional locations of static files
 STATICFILES_DIRS = (
-    INSTANCE_STATIC,
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.


### PR DESCRIPTION
This add a a templatetag which checks for an instance specific
stylesheets in /static/{instance_name}/css/custom.css. If this is
present then it outputs the link tag to load the stylesheet otherwise an
empty string.