### PR TITLE
Fix some DateField defaults (should be 'now', not 'now()')

### DIFF
--- a/nuntium/migrations/0002_fix_bad_datetime_defaults.py
+++ b/nuntium/migrations/0002_fix_bad_datetime_defaults.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nuntium', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='confirmation',
+            name='created',
+            field=models.DateField(default=django.utils.timezone.now),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messagerecord',
+            name='datetime',
+            field=models.DateField(default=django.utils.timezone.now),
+            preserve_default=True,
+        ),
+    ]

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -50,7 +50,7 @@ def template_with_wrap(template, context):
 
 class MessageRecord(models.Model):
     status = models.CharField(max_length=255)
-    datetime = models.DateField(default=now())
+    datetime = models.DateField(default=now)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
     content_object = generic.GenericForeignKey('content_type', 'object_id')
@@ -606,7 +606,7 @@ class ConfirmationTemplate(models.Model):
 class Confirmation(models.Model):
     message = models.OneToOneField(Message)
     key = models.CharField(max_length=64, unique=True)
-    created = models.DateField(default=now())
+    created = models.DateField(default=now)
     confirmated_at = models.DateField(default=None, null=True)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
The default for two DateField fields was now(), which would evaluate to
the current date and time at the point when the class is defined; what's
usually intended is that the default is the function 'now', which will
be evaluted when an instance of the model is created.  This commit makes
that change, including the corresponding migration.