### PR TITLE
Redirects from / to a language-specific variant shouldn't be permanent

### DIFF
--- a/nuntium/tests/home_view_tests.py
+++ b/nuntium/tests/home_view_tests.py
@@ -21,7 +21,7 @@ class HomeViewTestCase(TestCase):
     def test_it_redirects_if_hitting_root(self):
         '''It redirects if we hit / '''
         response = Client().get('/')
-        self.assertEquals(response.status_code, 301)
+        self.assertEquals(response.status_code, 302)
         self.assertEquals(response.url, reverse('home'))
 
     def test_list_instances(self):

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -188,8 +188,10 @@ class ConfirmView(RedirectView):
 
 
 class RootRedirectView(RedirectView):
-    def get_redirect_url(self, **kwargs):
 
+    permanent = False
+
+    def get_redirect_url(self, **kwargs):
         url = reverse("home")
         return url
 


### PR DESCRIPTION
It's annoying for local development that the redirect that's returned
from '/' is a permanent redirect (301) since then localhost:8000
redirects to, say, http://127.0.0.1.xip.io:8000/en/ even when working
on other sites, meaning you need to clear your browser's redirect cache
(not simple on all browsers).

It seems wrong that this is a permanent redirect anyway, since the
language prefix on the URL depends on Accept-Language, and you might
change languages in your browser.

This commit changes the redirect to 302 Found; widely interpreted as a
temporary redirect.

Fixes #1170