### PR TITLE
Add gettext dependency to vagrant provision.sh

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -53,13 +53,13 @@ cd /vagrant
 echo "-------------------------------------------------------
 Welcome to the WriteIt vagrant machine
 
+Add some seed data to your instance with:
+  ./manage.py loaddata example_data.yaml
+
 Run the web server with:
   ./manage.py runserver 0.0.0.0:8000
 
 Then visit http://127.0.0.1.xip.io:8000/ to use WriteIt
-
-Add some seed data to your instance with:
-  ./manage.py loaddata example_data.yaml
 
 Run a celery worker with:
   ./manage.py celery worker

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -29,7 +29,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python-dev python-pip python-virtualenv \
   rabbitmq-server \
   openjdk-7-jre elasticsearch \
-  mongodb-org nodejs
+  mongodb-org nodejs \
+  gettext
 
 # Set virtualenv directory and create it if needed.
 virtualenv_dir="/home/vagrant/writeit-virtualenv"


### PR DESCRIPTION
Not sure whether this has been added in the right place, but I needed gettext to make django work in the vagrant vm.

I've also swapped the order of the setup steps in the shell login message, because if you don't load the example data first, django will automatically redirect you to example.com and you'll have no idea why.