### PR TITLE
Fix intermittent test failures

### DIFF
--- a/example_data.yaml
+++ b/example_data.yaml
@@ -33,16 +33,16 @@
 - fields: {testing_mode: false, writeitinstance: 2, default_language: 'es'}
   model: instance.writeitinstanceconfig
   pk: 2
-- fields: {content: Content 1, subject: Subject 1, confirmated: False, writeitinstance: 1, slug: subject-1, author_name: Fiera, author_email: fiera@ciudadanointeligente.org }
+- fields: {content: Content 1, subject: Subject 1, confirmated: False, writeitinstance: 1, slug: subject-1, author_name: Fiera, author_email: fiera@ciudadanointeligente.org, created: '2016-01-20 09:00:00'}
   model: nuntium.message
   pk: 1
-- fields: {content: Content 2, subject: Subject 2, confirmated: True, writeitinstance: 1, slug: subject-2, author_name: Fiera, author_email: fiera@ciudadanointeligente.org}
+- fields: {content: Content 2, subject: Subject 2, confirmated: True, writeitinstance: 1, slug: subject-2, author_name: Fiera, author_email: fiera@ciudadanointeligente.org, created: '2016-01-21 10:30:00'}
   model: nuntium.message
   pk: 2
-- fields: {content: Private Message, public: False, confirmated: True, subject: This is private, writeitinstance: 1, slug: private-message, author_name: Fiera, author_email: fiera@ciudadanointeligente.org}
+- fields: {content: Private Message, public: False, confirmated: True, subject: This is private, writeitinstance: 1, slug: private-message, author_name: Fiera, author_email: fiera@ciudadanointeligente.org, created: '2016-01-24 17:45:00'}
   model: nuntium.message
   pk: 3
-- fields: {content: Content 4, subject: Subject 4, confirmated: True, writeitinstance: 2, slug: subject-4, author_name: Fiera, author_email: fiera@ciudadanointeligente.org}
+- fields: {content: Content 4, subject: Subject 4, confirmated: True, writeitinstance: 2, slug: subject-4, author_name: Fiera, author_email: fiera@ciudadanointeligente.org, created: '2016-01-25 13:00:00'}
   model: nuntium.message
   pk: 4
 - fields: {contact: 1, message: 1, site: 1}

--- a/nuntium/tests/api/page_paginator_test.py
+++ b/nuntium/tests/api/page_paginator_test.py
@@ -63,4 +63,6 @@ class PagePaginationTestCase(ResourceTestCase):
         # in order to be in the api
 
         messages = self.deserialize(response)['objects']
-        self.assertEquals(messages[0]['id'], Message.public_objects.all()[1].id)
+        self.assertEquals(
+            messages[0]['id'],
+            Message.public_objects.order_by('-created')[1].id)


### PR DESCRIPTION
We would occasionally get failures from the test:

  nuntium.tests.api.page_paginator_test:PagePaginationTestCase.test_get_paginated

I believe this is may be because of a couple of problems:

  - The messages returned from the API are ordered by their 'created'
    attribute, but the messages created from the fixtures had 'created'
    set to None. This means they may have been returned in an arbitrary
    order.

  - The list of public objects used to compare against was not
    explicitly ordered, so the order these are returned would have been
    arbitrary (well, database-specific anyway) as well.

This commit fixes both of those issues, so that hopefully these
transient test failures won't happen any more.