### PR TITLE
More fixes for "comma and 'and'" joining in non-English languages

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -183,9 +183,6 @@ class Message(models.Model):
             name = _('Anonymous')
         return name
 
-    def recipient_names_comma_joined(self):
-        return ', '.join(p.name for p in self.people)
-
     @property
     def outbound_messages(self):
         no_contact_oms = NoContactOM.objects.filter(message=self)

--- a/nuntium/templates/nuntium/profiles/messages_per_instance.html
+++ b/nuntium/templates/nuntium/profiles/messages_per_instance.html
@@ -7,6 +7,7 @@
 {% endblock extrajs %}
 {% load nuntium_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
 
 
 
@@ -53,7 +54,7 @@
               <h3><a class="explanation" data-toggle="tooltip" data-placement="right" title="{% trans "Link to message admin" %}" 
                 href="{% url 'message_detail_private' subdomain=writeitinstance.slug pk=message.pk %}">{{ message.subject }}</a> </h3>
               <p class="message-in-message-list__meta">
-                {% blocktrans with created=message.created|timesince author_name=message.author_name to=message.people|join_with_commas %}
+                {% blocktrans with created=message.created|timesince author_name=message.author_name to=message.people|join_with_commas:LANGUAGE_CODE %}
                   Sent <strong>{{ created }}</strong> ago to <strong>{{ to }}</strong> from <strong>{{ author_name }}</strong>
                 {% endblocktrans %}
               </p>

--- a/nuntium/templates/nuntium/profiles/moderation_queue.html
+++ b/nuntium/templates/nuntium/profiles/moderation_queue.html
@@ -7,7 +7,7 @@
 {% endblock extrajs %}
 {% load nuntium_tags %}
 
-
+{% get_current_language as LANGUAGE_CODE %}
 
 
 
@@ -49,7 +49,7 @@
               <h3><a class="explanation" data-toggle="tooltip" data-placement="right" title="{% trans "Link to message admin" %}" 
                 href="{% url 'message_detail_private' subdomain=writeitinstance.slug pk=message.pk %}">{{ message.subject }}</a> </h3>
               <p class="message-in-message-list__meta">
-                {% blocktrans with created=message.created|timesince author_name=message.author_name to=message.people|join_with_commas %}
+                {% blocktrans with created=message.created|timesince author_name=message.author_name to=message.people|join_with_commas:LANGUAGE_CODE %}
                   Sent <strong>{{ created }}</strong> ago to <strong>{{ to }}</strong> from <strong>{{ author_name }}</strong>
                 {% endblocktrans %}
               </p>

--- a/nuntium/templates/thread/message.html
+++ b/nuntium/templates/thread/message.html
@@ -7,9 +7,9 @@
         <dd>
           {% for person in message.people %}
             {% if person_links %}
-              <a href="{% url 'thread_to' pk=person.pk %}" title="{% blocktrans with name=person.name %}Show all messages to {{ name }}{% endblocktrans %}">{{ person.name }}</a>{% if not forloop.last %},{% endif %}
+              <a href="{% url 'thread_to' pk=person.pk %}" title="{% blocktrans with name=person.name %}Show all messages to {{ name }}{% endblocktrans %}">{{ person.name }}</a>{% if not forloop.last %} , {% endif %}
             {% else %}
-              {{ person.name }}{% if not forloop.last %},{% endif %}
+              {{ person.name }}{% if not forloop.last %} , {% endif %}
             {% endif %}
           {% empty %}
             &nbsp;

--- a/nuntium/templates/thread/message_mini.html
+++ b/nuntium/templates/thread/message_mini.html
@@ -1,10 +1,13 @@
 {% load i18n %}
+{% load nuntium_tags %}
+
+{% get_current_language as LANGUAGE_CODE %}
 
 <div class="mini-thread">
     <a href="{% url 'thread_read' slug=message.slug %}" class="mini-thread__message mini-thread__message--selected">
         <h3 class="mini-thread__message__summary">{{ message.subject }}</h3>
         <p class="mini-thread__message__person">{% trans "To:" %}
-        {% for person in message.people %}{% if not forloop.first and forloop.last %} {% trans "and" %} {% elif not forloop.first %}, {% endif %}{{ person.name }}{% endfor %}
+          {{ message.people|join_with_commas:LANGUAGE_CODE }}
         </p>
         {% if message.created %}
         <p class="mini-thread__message__date">{{ message.created }}</p>

--- a/nuntium/templates/write/draft.html
+++ b/nuntium/templates/write/draft.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load nuntium_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
 {% block content_inner %}
 
     {% include "write/breadcrumb.html" with current_step=2 %}
@@ -11,7 +13,7 @@
         {{ form.non_field_errors }}
         <p class="form-group">
             <label>{% trans "To" %}</label>
-            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas }}</span>
+            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas:LANGUAGE_CODE }}</span>
         </p>
         <p class="form-group">
             <label for="id_draft-subject">{% trans "Subject" %}</label>

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -22,7 +22,7 @@ register.inclusion_tag('nuntium/profiles/contacts/show_contacts_in.html')(show_c
 
 
 @register.filter
-def join_with_commas(obj_list):
+def join_with_commas(obj_list, language_code=None):
     """Takes a list of objects and returns their unicode representations,
     seperated by commas and with 'and' between the penultimate and final items
     For example, for a list of fruit objects:
@@ -35,7 +35,10 @@ def join_with_commas(obj_list):
     elif list_len == 1:
         return u"%s" % obj_list[0]
     else:
-        return u", ".join(unicode(obj) for obj in obj_list[:list_len - 1]) + u" and " + unicode(obj_list[list_len - 1])
+        if (language_code is None) or language_code.startswith('en'):
+            return u", ".join(unicode(obj) for obj in obj_list[:list_len - 1]) + u" and " + unicode(obj_list[list_len - 1])
+        else:
+            return u" , ".join(unicode(obj) for obj in obj_list)
 
 
 @register.assignment_tag(takes_context=True)

--- a/nuntium/tests/messages_test.py
+++ b/nuntium/tests/messages_test.py
@@ -282,18 +282,6 @@ class TestMessages(TestCase):
         self.assertIn(self.person2, message.people.all())
         self.assertEquals(message.people.count(), 2)
 
-    def test_comma_joining_of_recipient_names(self):
-        message = Message.objects.create(
-            content='Content 1',
-            author_name='Felipe',
-            author_email="falvarez@votainteligente.cl",
-            subject='Same subject hey',
-            writeitinstance=self.writeitinstance1,
-            persons=[self.person1, self.person2],
-            )
-
-        self.assertEquals(message.recipient_names_comma_joined(), "Pedro, Marcel")
-
     def test_a_person_has_a_messages_property(self):
         Message.objects.all().delete()
         message = Message.objects.create(

--- a/nuntium/user_section/tests/template_tags_tests.py
+++ b/nuntium/user_section/tests/template_tags_tests.py
@@ -43,6 +43,30 @@ class ListContactsTemplateTag(TestCase):
         rendered = t.render(c)
         self.assertEquals(u'Pedro, Marcel and Felipe', rendered)
 
+    def test_join_with_commas_another_language(self):
+        '''
+        Join a list with commas in a non-English language
+        '''
+        t = Template('{% load nuntium_tags %}{{ people|join_with_commas:"fa" }}')
+        people = Person.objects.all().order_by('id')
+        c = Context({
+            "people": people
+            })
+        rendered = t.render(c)
+        self.assertEquals(u'Pedro , Marcel , Felipe', rendered)
+
+    def test_join_with_commas_english(self):
+        '''
+        Join a list with commas in a non-English language
+        '''
+        t = Template('{% load nuntium_tags %}{{ people|join_with_commas:"en" }}')
+        people = Person.objects.all().order_by('id')
+        c = Context({
+            "people": people
+            })
+        rendered = t.render(c)
+        self.assertEquals(u'Pedro, Marcel and Felipe', rendered)
+
     def test_get_url_using_subdomain(self):
         '''
         There is a problem with the subdomain urls wich doesn't allow me to do the following

--- a/writeit/templates/subdomains/infoszab/write/draft.html
+++ b/writeit/templates/subdomains/infoszab/write/draft.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load nuntium_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
+
 {% block content_inner %}
 
     {% include "write/breadcrumb.html" with current_step=2 %}
@@ -11,7 +14,7 @@
         {{ form.non_field_errors }}
         <p class="form-group">
             <label>{% trans "To" %}</label>
-            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas }}</span>
+            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas:LANGUAGE_CODE }}</span>
         </p>
         <p class="form-group">
             <label for="id_draft-subject">{% trans "Subject" %}</label>

--- a/writeit/templates/subdomains/iran/nuntium/instance_detail.html
+++ b/writeit/templates/subdomains/iran/nuntium/instance_detail.html
@@ -28,7 +28,7 @@
               names.
             {% endcomment %}
             {% if LANGUAGE_CODE == 'fa' %}
-              {% blocktrans trimmed with recipient_names=message.recipient_names_comma_joined %}
+              {% blocktrans trimmed with recipient_names=message.people|join_with_commas:LANGUAGE_CODE %}
                 Dear {{ recipient_names }},
               {% endblocktrans %}
             {% else %}

--- a/writeit/templates/subdomains/iran/thread/message.html
+++ b/writeit/templates/subdomains/iran/thread/message.html
@@ -6,9 +6,9 @@
                     <p><span>{% trans "To" %}: </span>
           {% for person in message.people %}
             {% if person_links %}
-              <a href="{% url 'thread_to' pk=person.pk %}" title="{% blocktrans with name=person.name %}Show all messages to {{ name }}{% endblocktrans %}">{{ person.name }}</a>{% if not forloop.last %},{% endif %}
+              <a href="{% url 'thread_to' pk=person.pk %}" title="{% blocktrans with name=person.name %}Show all messages to {{ name }}{% endblocktrans %}">{{ person.name }}</a>{% if not forloop.last %} , {% endif %}
             {% else %}
-              {{ person.name }}{% if not forloop.last %},{% endif %}
+              {{ person.name }}{% if not forloop.last %} , {% endif %}
             {% endif %}
           {% empty %}
             &nbsp;

--- a/writeit/templates/subdomains/iran/write/draft.html
+++ b/writeit/templates/subdomains/iran/write/draft.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load nuntium_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
 {% block promo %}
 {% endblock %}
 
@@ -16,7 +18,7 @@
         {{ form.non_field_errors }}
         <p class="form-group">
             <label>{% trans "To" %}</label>
-            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas }}</span>
+            <span class="form-control writing-draft-recipients">{{ message.persons|join_with_commas:LANGUAGE_CODE }}</span>
         </p>
         <p class="form-group">
             <label for="id_draft-subject">{% trans "Subject" %}</label>


### PR DESCRIPTION
These are attempted fixes for #26 and a fix for "and" being used
in between the last two elements of a list in non-English
languages.