### PR TITLE
More moderated viewing fixes

### DIFF
--- a/nuntium/tests/moderation_messages_test.py
+++ b/nuntium/tests/moderation_messages_test.py
@@ -74,6 +74,51 @@ class ModerationMessagesTestCase(TestCase):
         self.assertEquals(response.context['awaiting_moderation'], True)
         self.assertContains(response, 'This message is awaiting moderation')
 
+    def test_can_view_moderated_message(self):
+        message = Message.objects.create(
+            content='Content 1',
+            author_name='Felipe',
+            author_email="falvarez@votainteligente.cl",
+            subject='Fiera es una perra feroz',
+            public=True,
+            writeitinstance=self.writeitinstance1,
+            persons=[self.person1],
+            )
+
+        message.recently_confirmated()
+
+        url = message.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertTrue(message.moderated)
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context['awaiting_moderation'], False)
+        self.assertContains(response, 'Fiera es una perra feroz')
+
+    def test_can_view_message_with_moderated_none(self):
+        message = Message.objects.create(
+            content='Content 1',
+            author_name='Felipe',
+            author_email="falvarez@votainteligente.cl",
+            subject='Fiera es una perra feroz',
+            public=True,
+            writeitinstance=self.writeitinstance1,
+            persons=[self.person1],
+            )
+
+        message.recently_confirmated()
+
+        message.moderated = None
+        message.save()
+
+        url = message.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context['awaiting_moderation'], False)
+        self.assertContains(response, 'Fiera es una perra feroz')
+
     def test_outbound_messages_of_a_confirmed_message_are_waiting_for_moderation(self):
         # I need to do a get to the confirmation url
         moderation, created = Moderation.objects.get_or_create(message=self.private_message)

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -264,12 +264,8 @@ class MessagesFromPersonView(ListView):
         return super(MessagesFromPersonView, self).dispatch(*args, **kwargs)
 
     def get_queryset(self):
-        qs = super(MessagesFromPersonView, self).get_queryset()
-        qs = qs.filter(
-            Q(moderated=True) | Q(moderated__isnull=True),
+        qs = Message.public_objects.filter(
             writeitinstance=self.writeitinstance,
-            public=True,
-            confirmated=True,
             author_email=self.message.author_email
         )
         if self.message.author_name == '':
@@ -290,12 +286,8 @@ class MessageThreadsView(ListView):
     template_name = 'thread/all.html'
 
     def get_queryset(self):
-        queryset = super(MessageThreadsView, self).get_queryset()
-        return queryset.filter(
-            Q(moderated=True) | Q(moderated__isnull=True),
+        return Message.public_objects.filter(
             writeitinstance__slug=self.request.subdomain,
-            public=True,
-            confirmated=True,
         )
 
     def get_context_data(self, **kwargs):

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -326,7 +326,7 @@ class MessageThreadView(MessageDetailView):
         context['writeitinstance'] = self.object.writeitinstance
         context['awaiting_moderation'] = False
         if self.object.writeitinstance.config.moderation_needed_in_all_messages and \
-                self.object.moderated != True:
+                self.object.moderated != True and self.object.moderated is not None:
             context['awaiting_moderation'] = True
         return context
 


### PR DESCRIPTION
Fixes the logic for the /read page so we do not hide messages that have been created before the current moderation code and have moderated=None.

Also tidy up the other message views to use the public_objects manager of Message rather than repeating the same filters in multiple place.