### PR TITLE
Fix the language prefix of links in emails

### DIFF
--- a/mailit/tests/plugin_test.py
+++ b/mailit/tests/plugin_test.py
@@ -137,6 +137,28 @@ class MailSendingTestCase(TestCase):
         self.assertEquals(len(message.to), 1)
         self.assertIn("pdaire@ciudadanointeligente.org", message.to)
 
+    def test_sending_email_links_for_default_language(self):
+        # Change the default language of the instance, and check that the
+        instance_config = self.outbound_message1.message.writeitinstance.config
+        instance_config.default_language = 'fa'
+        instance_config.save()
+
+        result_of_sending, fatal_error = self.channel.send(self.outbound_message1)
+
+        self.assertTrue(result_of_sending)
+        self.assertTrue(fatal_error is None)
+        self.assertEquals(len(mail.outbox), 1)  # it is sent to one person pointed in the contact
+        message = mail.outbox[0]
+
+        # Note that the '/fa/' part of these links is what we're
+        # really looking for:
+        self.assertIn(
+            'via instance 1 (http://instance1.127.0.0.1.xip.io:8000/fa/)',
+            message.body)
+        self.assertIn(
+            'will be published at http://instance1.127.0.0.1.xip.io:8000/fa/thread/subject-1/',
+            message.body)
+
     @override_settings(EMAIL_SUBJECT_PREFIX='[WriteIT]')
     def test_content_justification(self):
         activate('en')

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -323,7 +323,7 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
         connection = writeitinstance.config.get_mail_connection()
         new_answer_template = writeitinstance.new_answer_notification_template
 
-        with override(None, deactivate=True):
+        with override(writeitinstance.config.default_language):
             message_url = reverse('thread_read', subdomain=writeitinstance.slug, kwargs={'slug': answer.message.slug})
 
         context = {

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -170,6 +170,23 @@ class NewAnswerNotificationToSubscribers(TestCase):
             self.instance.slug + "@" + settings.DEFAULT_FROM_DOMAIN,
             )
 
+    def test_new_answer_notification_email_uses_sensible_language(self):
+        self.instance.config.default_language = 'fa'
+        self.instance.config.save()
+
+        self.create_a_new_answer()
+
+        self.assertEquals(len(mail.outbox), 1)
+        self.assertEquals(len(mail.outbox[0].to), 1)
+        self.assertFalse(mail.outbox[0].alternatives)
+        self.assertEquals(mail.outbox[0].to[0], self.subscriber.email)
+
+        message_body = mail.outbox[0].body
+
+        self.assertIn(
+            'http://instance1.127.0.0.1.xip.io:8000/fa/thread/subject-1/',
+            message_body)
+
     def test_answer_notification_with_html(self):
         # Put some html in the new answer notification template
         new_answer_notification_template = self.message.writeitinstance.new_answer_notification_template


### PR DESCRIPTION
The confirmation email already used the current language
as a language prefix in the URLs. However, the new answer
notification email and the outgoing message email are sent
from other contexts (from celery beat or in response to a
new email arriving) where there is no HTTP request to
provide a preferred language. However, each of these emails
is associated with an instance, and their config has a default
language. These commits make sure that default language
is used in the links in these emails.