### PR TITLE
Migration to django-popolo part 2

### DIFF
--- a/contactos/migrations/0003_denull_popolo_people.py
+++ b/contactos/migrations/0003_denull_popolo_people.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contactos', '0002_contact_popolo_person'),
+        ('instance', '0004_add_django_popolo_people'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='popolo_person',
+            field=models.ForeignKey(to='popolo.Person'),
+            preserve_default=True,
+        ),
+    ]

--- a/contactos/migrations/0004_remove_contact_person.py
+++ b/contactos/migrations/0004_remove_contact_person.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contactos', '0003_denull_popolo_people'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='contact',
+            name='person',
+        ),
+    ]

--- a/contactos/migrations/0005_rename_migrated_fields.py
+++ b/contactos/migrations/0005_rename_migrated_fields.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contactos', '0004_remove_contact_person'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='contact',
+            old_name='popolo_person',
+            new_name='person',
+        ),
+    ]

--- a/contactos/models.py
+++ b/contactos/models.py
@@ -21,7 +21,7 @@ class ContactType(models.Model):
 class Contact(models.Model):
     """docstring for Contact"""
     contact_type = models.ForeignKey('ContactType')
-    popolo_person = models.ForeignKey(Person)
+    person = models.ForeignKey(Person)
     value = models.CharField(max_length=512)
     is_bounced = models.BooleanField(default=False)
     owner = models.ForeignKey(User, related_name="contacts", null=True)

--- a/contactos/models.py
+++ b/contactos/models.py
@@ -23,7 +23,7 @@ class Contact(models.Model):
     """docstring for Contact"""
     contact_type = models.ForeignKey('ContactType')
     person = models.ForeignKey(Person)
-    popolo_person = models.ForeignKey(PopoloPerson, null=True, blank=True)
+    popolo_person = models.ForeignKey(PopoloPerson)
     value = models.CharField(max_length=512)
     is_bounced = models.BooleanField(default=False)
     owner = models.ForeignKey(User, related_name="contacts", null=True)

--- a/contactos/models.py
+++ b/contactos/models.py
@@ -1,6 +1,5 @@
 from django.db import models
-from popit.models import Person
-from popolo.models import Person as PopoloPerson
+from popolo.models import Person as Person
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User
 from django.db.models.signals import pre_save
@@ -22,8 +21,7 @@ class ContactType(models.Model):
 class Contact(models.Model):
     """docstring for Contact"""
     contact_type = models.ForeignKey('ContactType')
-    person = models.ForeignKey(Person)
-    popolo_person = models.ForeignKey(PopoloPerson)
+    popolo_person = models.ForeignKey(Person)
     value = models.CharField(max_length=512)
     is_bounced = models.BooleanField(default=False)
     owner = models.ForeignKey(User, related_name="contacts", null=True)

--- a/global_test_case.py
+++ b/global_test_case.py
@@ -6,7 +6,6 @@ from django.core.management import call_command
 from tastypie.test import ResourceTestCase
 from django.conf import settings
 from django.contrib.sites.models import Site
-from popit.tests import instance_helpers
 import os
 import subprocess
 import threading

--- a/instance/migrations/0005_denull_popolo_source.py
+++ b/instance/migrations/0005_denull_popolo_source.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0004_add_django_popolo_people'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='writeitinstancepopitinstancerecord',
+            name='popolo_source',
+            field=models.ForeignKey(to='popolo_sources.PopoloSource'),
+            preserve_default=True,
+        ),
+    ]

--- a/instance/migrations/0006_remove_old_fields.py
+++ b/instance/migrations/0006_remove_old_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0005_denull_popolo_source'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='membership',
+            name='person',
+        ),
+        migrations.RemoveField(
+            model_name='membership',
+            name='writeitinstance',
+        ),
+        migrations.RemoveField(
+            model_name='writeitinstance',
+            name='persons',
+        ),
+        migrations.DeleteModel(
+            name='Membership',
+        ),
+    ]

--- a/instance/migrations/0007_rename_migrated_fields.py
+++ b/instance/migrations/0007_rename_migrated_fields.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0006_remove_old_fields'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='writeitinstance',
+            old_name='popolo_persons',
+            new_name='persons',
+        ),
+    ]

--- a/instance/migrations/0008_remove_writeitinstancepopitinstancerecord_popitapiinstance.py
+++ b/instance/migrations/0008_remove_writeitinstancepopitinstancerecord_popitapiinstance.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0007_rename_migrated_fields'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='writeitinstancepopitinstancerecord',
+            name='popitapiinstance',
+        ),
+    ]

--- a/instance/models.py
+++ b/instance/models.py
@@ -23,7 +23,7 @@ class WriteItInstance(models.Model):
     name = models.CharField(max_length=255)
     description = models.CharField(max_length=512, blank=True)
     slug = AutoSlugField(populate_from='name', unique=True)
-    popolo_persons = models.ManyToManyField(PopoloPerson,
+    persons = models.ManyToManyField(PopoloPerson,
         related_name='writeit_instances',
         through='InstanceMembership')
     owner = models.ForeignKey(User, related_name="writeitinstances")

--- a/instance/models.py
+++ b/instance/models.py
@@ -148,7 +148,6 @@ class WriteitInstancePopitInstanceRecord(models.Model):
         ("inprogress", _("In Progress")),
         )
     writeitinstance = models.ForeignKey(WriteItInstance)
-    popitapiinstance = models.ForeignKey(ApiInstance)
     popolo_source = models.ForeignKey(PopoloSource)
     periodicity = models.CharField(
         max_length="2",

--- a/instance/models.py
+++ b/instance/models.py
@@ -23,9 +23,6 @@ class WriteItInstance(models.Model):
     name = models.CharField(max_length=255)
     description = models.CharField(max_length=512, blank=True)
     slug = AutoSlugField(populate_from='name', unique=True)
-    persons = models.ManyToManyField(Person,
-        related_name='writeit_instances',
-        through='Membership')
     popolo_persons = models.ManyToManyField(PopoloPerson,
         related_name='writeit_instances',
         through='InstanceMembership')
@@ -113,11 +110,6 @@ class WriteItInstance(models.Model):
 
     def __unicode__(self):
         return self.name
-
-
-class Membership(models.Model):
-    person = models.ForeignKey(Person)
-    writeitinstance = models.ForeignKey(WriteItInstance)
 
 
 class InstanceMembership(models.Model):

--- a/instance/models.py
+++ b/instance/models.py
@@ -157,7 +157,7 @@ class WriteitInstancePopitInstanceRecord(models.Model):
         )
     writeitinstance = models.ForeignKey(WriteItInstance)
     popitapiinstance = models.ForeignKey(ApiInstance)
-    popolo_source = models.ForeignKey(PopoloSource, null=True, blank=True)
+    popolo_source = models.ForeignKey(PopoloSource)
     periodicity = models.CharField(
         max_length="2",
         choices=PERIODICITY,

--- a/nuntium/admin.py
+++ b/nuntium/admin.py
@@ -16,7 +16,7 @@ class PersonInline(admin.TabularInline):
 
 
 class MembershipInline(admin.TabularInline):
-    model = WriteItInstance.persons.through
+    model = WriteItInstance.popolo_persons.through
 
 
 class NewAnswerNotificationTemplateAdmin(admin.TabularInline):

--- a/nuntium/admin.py
+++ b/nuntium/admin.py
@@ -16,7 +16,7 @@ class PersonInline(admin.TabularInline):
 
 
 class MembershipInline(admin.TabularInline):
-    model = WriteItInstance.popolo_persons.through
+    model = WriteItInstance.persons.through
 
 
 class NewAnswerNotificationTemplateAdmin(admin.TabularInline):

--- a/nuntium/migrations/0003_denull_popolo_people.py
+++ b/nuntium/migrations/0003_denull_popolo_people.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nuntium', '0003_add_parallel_popolo_data'),
+        ('instance', '0004_add_django_popolo_people'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='answer',
+            name='popolo_person',
+            field=models.ForeignKey(to='popolo.Person'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='nocontactom',
+            name='popolo_person',
+            field=models.ForeignKey(to='popolo.Person'),
+            preserve_default=True,
+        ),
+    ]

--- a/nuntium/migrations/0004_remove_old_fields.py
+++ b/nuntium/migrations/0004_remove_old_fields.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nuntium', '0003_denull_popolo_people'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='answer',
+            name='person',
+        ),
+        migrations.RemoveField(
+            model_name='nocontactom',
+            name='person',
+        ),
+    ]

--- a/nuntium/migrations/0005_rename_migrated_fields.py
+++ b/nuntium/migrations/0005_rename_migrated_fields.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nuntium', '0004_remove_old_fields'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='answer',
+            old_name='popolo_person',
+            new_name='person',
+        ),
+        migrations.RenameField(
+            model_name='nocontactom',
+            old_name='popolo_person',
+            new_name='person',
+        ),
+    ]

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -318,7 +318,7 @@ pre_save.connect(slugify_message, sender=Message)
 class Answer(models.Model):
     content = models.TextField()
     content_html = models.TextField()
-    popolo_person = models.ForeignKey(PopoloPerson)
+    person = models.ForeignKey(PopoloPerson)
     message = models.ForeignKey(Message, related_name='answers')
     created = models.DateTimeField(auto_now=True, null=True)
 
@@ -436,7 +436,7 @@ class AbstractOutboundMessage(models.Model):
 
 
 class NoContactOM(AbstractOutboundMessage):
-    popolo_person = models.ForeignKey(PopoloPerson)
+    person = models.ForeignKey(PopoloPerson)
 
 
 # This will happen everytime a contact is created

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -318,7 +318,6 @@ pre_save.connect(slugify_message, sender=Message)
 class Answer(models.Model):
     content = models.TextField()
     content_html = models.TextField()
-    person = models.ForeignKey(Person)
     popolo_person = models.ForeignKey(PopoloPerson)
     message = models.ForeignKey(Message, related_name='answers')
     created = models.DateTimeField(auto_now=True, null=True)
@@ -437,7 +436,6 @@ class AbstractOutboundMessage(models.Model):
 
 
 class NoContactOM(AbstractOutboundMessage):
-    person = models.ForeignKey(Person)
     popolo_person = models.ForeignKey(PopoloPerson)
 
 

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -319,7 +319,7 @@ class Answer(models.Model):
     content = models.TextField()
     content_html = models.TextField()
     person = models.ForeignKey(Person)
-    popolo_person = models.ForeignKey(PopoloPerson, null=True, blank=True)
+    popolo_person = models.ForeignKey(PopoloPerson)
     message = models.ForeignKey(Message, related_name='answers')
     created = models.DateTimeField(auto_now=True, null=True)
 
@@ -438,7 +438,7 @@ class AbstractOutboundMessage(models.Model):
 
 class NoContactOM(AbstractOutboundMessage):
     person = models.ForeignKey(Person)
-    popolo_person = models.ForeignKey(PopoloPerson, null=True, blank=True)
+    popolo_person = models.ForeignKey(PopoloPerson)
 
 
 # This will happen everytime a contact is created

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -211,7 +211,11 @@ INSTALLED_APPS = (
     'nuntium',
     'djangoplugins',
     'pagination',
+
+    # Although django-popit is unused now, we need to keep it
+    # installed because the earlier migrations depend on its presence.
     'popit',
+
     'popolo',
     'popolo_sources',
     'contactos',


### PR DESCRIPTION
This is the second part of: #1181 for review. See that pull request for the context for this pull request.

This removes the old popit-django model references.