### PR TITLE
Use the Jalali calendar for datetime rendering in Persian

### DIFF
--- a/nuntium/templates/nuntium/message/message_detail.html
+++ b/nuntium/templates/nuntium/message/message_detail.html
@@ -3,6 +3,10 @@
 {% load subdomainurls %}
 {% block content %}
 {% load markdown_deux_tags %}
+{% load nuntium_tags %}
+
+{% get_current_language as LANGUAGE_CODE %}
+
 <div class="panel panel-default container-fluid">
   <div class="panel-heading row">
     <h1 class="panel-title">{{ message.subject }}</h1>
@@ -23,7 +27,7 @@
     <a href="{{other_messages_by}}">{{ name }}</a>.{% endblocktrans %}</small></span>
     <div class='col-md-4 col-md-offset-4'>
       {% if message.created %}
-      {{ message.created }}
+      {{ message.created|localize_datetime:LANGUAGE_CODE }}
       {% endif %}</div>
 
   </div>

--- a/nuntium/templates/nuntium/message/message_in_list.html
+++ b/nuntium/templates/nuntium/message/message_in_list.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load subdomainurls %}
 {% load markdown_deux_tags %}
+{% load nuntium_tags %}
+
+{% get_current_language as LANGUAGE_CODE %}
 
 <dl class="dl-horizontal">
     <div class="panel panel-default">
@@ -35,7 +38,7 @@
             <a href="{{other_messages_by}}">{{ name }}</a>.{% endblocktrans %}</small></span>
             <div class='col-md-4 col-md-offset-4'>
               {% if message.created %}
-                {{ message.created }}
+                {{ message.created|localize_datetime:LANGUAGE_CODE }}
               {% endif %}
             </div>
         </div>

--- a/nuntium/templates/nuntium/profiles/message_detail.html
+++ b/nuntium/templates/nuntium/profiles/message_detail.html
@@ -4,6 +4,8 @@
 {% load staticfiles %}
 {% load nuntium_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
 {% block extrajs %}
 {% endblock extrajs %}
 
@@ -47,7 +49,7 @@
 	  <dd><a href="{% url 'thread_read' slug=message.slug subdomain=message.writeitinstance.slug %}"><i class="fa fa-link"></i> {% trans "Public page" %}</a></dd>
 	  {% endif %}
 	  <dt>{% trans "Creation Date" %}</dt>
-	  <dd>{{ message.created }}</dd>
+	  <dd>{{ message.created|localize_datetime:LANGUAGE_CODE }}</dd>
       <dt>{% trans "Content" %}</dt>
       <dd>{{ message.content|linebreaksbr }}</dd>
 	</dl>

--- a/nuntium/templates/thread/answer.html
+++ b/nuntium/templates/thread/answer.html
@@ -2,6 +2,8 @@
 
 {# :TODO: Might want to merge this into /thread/message.html? #}
 
+{% get_current_language as LANGUAGE_CODE %}
+
 <div class="message message--reply">
     <dl class="message__meta">
 
@@ -18,7 +20,7 @@
 
         {% if answer.created %}
             <dt>{% trans "Date" %}</dt>
-            <dd>{{ answer.created }}</dd>
+            <dd>{{ answer.created|localize_datetime:LANGUAGE_CODE }}</dd>
         {% endif %}
 
     </dl>

--- a/nuntium/templates/thread/message.html
+++ b/nuntium/templates/thread/message.html
@@ -1,4 +1,7 @@
 {% load i18n %}
+{% load nuntium_tags %}
+
+{% get_current_language as LANGUAGE_CODE %}
 
 <div class="message {% if recently_sent %}message--sent{% endif %}">
     <dl class="message__meta">
@@ -38,7 +41,7 @@
 
         {% if message.created %}
             <dt>{% trans "Date" %}</dt>
-            <dd>{{ message.created }}</dd>
+            <dd>{{ message.created|localize_datetime:LANGUAGE_CODE }}</dd>
         {% endif %}
 
     </dl>

--- a/nuntium/templates/thread/message_mini.html
+++ b/nuntium/templates/thread/message_mini.html
@@ -10,7 +10,7 @@
           {{ message.people|join_with_commas:LANGUAGE_CODE }}
         </p>
         {% if message.created %}
-        <p class="mini-thread__message__date">{{ message.created }}</p>
+        <p class="mini-thread__message__date">{{ message.created|localize_datetime:LANGUAGE_CODE }}</p>
         {% endif %}
     </a>
 
@@ -22,7 +22,7 @@
             {% endblocktrans %}
         </p>
         {% if answer.created %}
-        <p class="mini-thread__message__date">{{ answer.created }}</p>
+        <p class="mini-thread__message__date">{{ answer.created|localize_datetime:LANGUAGE_CODE }}</p>
         {% endif %}
     </a>
     {% endfor %}

--- a/nuntium/templatetags/nuntium_tags.py
+++ b/nuntium/templatetags/nuntium_tags.py
@@ -1,5 +1,6 @@
 import os
 import re
+from khayyam import JalaliDatetime
 from django import template
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -39,6 +40,15 @@ def join_with_commas(obj_list, language_code=None):
             return u", ".join(unicode(obj) for obj in obj_list[:list_len - 1]) + u" and " + unicode(obj_list[list_len - 1])
         else:
             return u", ".join(unicode(obj) for obj in obj_list)
+
+
+@register.filter
+def localize_datetime(dt, language_code=None):
+    if language_code == 'fa':
+        jdt = JalaliDatetime(dt)
+        return jdt.strftime('%C')
+    else:
+        return dt
 
 
 @register.assignment_tag(takes_context=True)

--- a/nuntium/tests/date_localization_tests.py
+++ b/nuntium/tests/date_localization_tests.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+from nuntium.templatetags.nuntium_tags import localize_datetime
+
+from django.utils.translation import override
+
+from django.template import Context, Template
+from global_test_case import GlobalTestCase as TestCase
+
+
+class DateLocalizationTests(TestCase):
+
+    def setUp(self):
+        self.dt = datetime(2015, 11, 28, 9, 45, 30)
+
+    def test_tag_in_isolation_language_en(self):
+        self.assertEqual(
+            localize_datetime(self.dt, 'en'),
+            self.dt)
+
+    def test_tag_in_isolation_language_es(self):
+        self.assertEqual(
+            localize_datetime(self.dt, 'es'),
+            self.dt)
+
+    def test_tag_in_isolation_language_fa(self):
+        self.assertEqual(
+            localize_datetime(self.dt, 'fa'),
+            u"شنبه ۷ آذر ۱۳۹۴ ۰۹:۴۵:۳۰ ق.ظ")
+
+    def test_tag_in_template_language_en(self):
+        template = Template('{% load nuntium_tags %}{{ dt|localize_datetime:"en" }}')
+        with override('en'):
+            self.assertEqual(
+                template.render(Context({'dt': self.dt})),
+                'Nov. 28, 2015, 9:45 a.m.')
+
+    def test_tag_in_template_language_es(self):
+        template = Template('{% load nuntium_tags %}{{ dt|localize_datetime:"es" }}')
+        with override('es'):
+            self.assertEqual(
+                template.render(Context({'dt': self.dt})),
+                '28 de Noviembre de 2015 a las 09:45')
+
+    def test_tag_in_template_language_fa(self):
+        template = Template('{% load nuntium_tags %}{{ dt|localize_datetime:"fa" }}')
+        with override('fa'):
+            self.assertEqual(
+                template.render(Context({'dt': self.dt})),
+                u'شنبه ۷ آذر ۱۳۹۴ ۰۹:۴۵:۳۰ ق.ظ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ futures==3.0.5
 gunicorn==19.6.0
 idna==2.1
 ipaddress==1.0.16
+Khayyam==3.0.15
 kombu==3.0.35
 libsass==0.11.1
 markdown2==2.3.1

--- a/writeit/templates/subdomains/iran/thread/answer.html
+++ b/writeit/templates/subdomains/iran/thread/answer.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
             <div class="letter-view container">
 
                 <div class="address">
@@ -14,7 +16,7 @@
           {% endwith %}
                     </p>
 
-                    <p><span>{% trans "Date" %}: </span>{{ answer.created }}</p>
+                    <p><span>{% trans "Date" %}: </span>{{ answer.created|localize_datetime:LANGUAGE_CODE }}</p>
                 </div>
 
                 <div class="content">{{ answer.content|linebreaksbr }}</div>

--- a/writeit/templates/subdomains/iran/thread/message.html
+++ b/writeit/templates/subdomains/iran/thread/message.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
             <div class="letter-view">
                 <div class="address">
 
@@ -30,7 +32,7 @@
                     <p><span>{% trans "Subject" %}: </span>{{ message.subject }}</p>
 
         {% if message.created %}
-                    <p><span>{% trans "Date" %}: </span>{{ message.created }}</p>
+                    <p><span>{% trans "Date" %}: </span>{{ message.created|localize_datetime:LANGUAGE_CODE }}</p>
         {% endif %}
 
               </div>


### PR DESCRIPTION
This uses the Khayyam Python package to convert datetimes to the Jalali
calendar.