### PR TITLE
Handle people who are missing email addresses more elegantly

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -7,3 +7,9 @@ file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
+
+[writeinpublic.javascript]
+file_filter = locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = locale/en/LC_MESSAGES/djangojs.po
+source_lang = en
+type = PO

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -97,7 +97,12 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1746,6 +1751,16 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1777,8 +1792,13 @@ msgstr ""
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr ""
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr ""
 
@@ -1893,6 +1913,11 @@ msgstr ""
 
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
+msgstr ""
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
 msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/mysociety/writeinpublic/language/ar/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -106,11 +106,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -119,12 +119,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -132,7 +132,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -258,9 +258,9 @@ msgstr ""
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr ""
 
@@ -389,47 +389,49 @@ msgid "No results found."
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -446,7 +448,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -489,14 +491,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -554,7 +556,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -582,79 +584,79 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -672,45 +674,45 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -719,74 +721,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1399,8 +1401,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1552,48 +1554,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr ""
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1623,19 +1625,19 @@ msgstr ""
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr ""
 
@@ -1646,7 +1648,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1663,7 +1665,7 @@ msgstr ""
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1676,17 +1678,17 @@ msgstr[5] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr ""
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr ""
@@ -1707,35 +1709,35 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1802,8 +1804,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr ""
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1821,7 +1823,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1903,15 +1905,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr ""
 

--- a/locale/ar/LC_MESSAGES/djangojs.po
+++ b/locale/ar/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Czech (http://www.transifex.com/mysociety/writeinpublic/language/cs/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -103,11 +103,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -116,12 +116,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -255,9 +255,9 @@ msgstr "Odhlásit se"
 msgid "This site is read-only."
 msgstr "Tato stránka je jen pro čtení."
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr "Momentálně nemůžete vytvořit novou zprávu."
 
@@ -352,7 +352,7 @@ msgstr "Napište těm, kdo Vás reprezentují <br /> Veřejně. </ br> Dostaňte
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr "Poslední zprávy"
 
@@ -386,47 +386,49 @@ msgid "No results found."
 msgstr "Žádné výsledky nenalezeny"
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr "Odesílatel: %(author_name)s"
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr "Aktuálně nejsou žádné veřejné zprávy."
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr "Vizte všechny zprávy adresované: %(person_name)s"
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr "<a href=\"%(other_messages_by)s\">%(name)s</a>"
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr "Odpovědi"
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr "Zpět na zprávy"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr "Zatím žádné zprávy"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -440,7 +442,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -483,14 +485,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr "Adresáti"
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -545,7 +547,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -573,79 +575,79 @@ msgstr "API"
 msgid "Stats"
 msgstr "Statistiky"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr "Předmět"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr "Autor"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr "Potvrzeno"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr "Moderováno"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr "Tato zpráva ještě nebyla moderována - klikněte zde a přijmete ji"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr "Přijmout"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr "Link"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr "Veřejná stránka"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr "Datum vytvoření"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr "Obsah"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr "Vytvořit odpověď"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr "Osoba"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr "Akce"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr "Upravit odpověď"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -660,45 +662,45 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr "Vlákno"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr "Odpovědi"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr "Veřejně?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr "Potvrzeno?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr "Nastavit soukromé/veřejné"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr "Link do administrace zprávy"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -707,74 +709,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr "Přidat"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr "Tuto zprávu mohou vidět všichni"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr "Odesílatel potvrdil, že tato zpráva byla odeslána ze svého emailu"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr "Odesílatel zatím nepotvrdil svůj email"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr "Zpráva byla přijata"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr "Nemáte žádné zprávy"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr "Smazat tuto zprávu?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1377,8 +1379,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1530,48 +1532,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr "Zobrazit všechny zprávy pro: %(name)s"
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr "Datum"
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr "Komu"
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr "Zobrazit všechny zprávy od: %(name)s"
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr "Adresáti neuvidí Vaší emailovou adresu"
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1601,19 +1603,19 @@ msgstr "Pošleme Vám email hned, jak přijde odpovověď."
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr "Také jsme zprávu zveřejnili a všechny odpovědi budou také veřejně dostupné."
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr "Odpovědi budou zveřejněny zde."
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr "Zpět na všechny zprávy"
 
@@ -1624,7 +1626,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1641,7 +1643,7 @@ msgstr "Napište této osobě"
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1651,17 +1653,17 @@ msgstr[2] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr "Napište zprávy"
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr "Náhled zprávy"
@@ -1682,35 +1684,35 @@ msgstr "Zpráva poslána"
 msgid "Send message"
 msgstr "Poslat zprávu"
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr "Vaše zpráva"
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr "Toto bude zveřejněno zde."
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr "Vaše jméno"
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr "Váš email"
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr "Toto nikdo nikdy neuvidí."
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1774,8 +1776,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr "Žádný adresát"
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1790,7 +1792,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1872,15 +1874,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr "Vaše zpráva <small>Toto bude zveřejněno zde.</small>"
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr "Vaše jméno <small>Toto bude zveřejněno zde.</small>"
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr "Váš email <small>Toto nikdo nikdy neuvidí.</small>"
 

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -94,7 +94,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1718,6 +1723,16 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1749,8 +1764,13 @@ msgstr "Zaslali jsme potvrzovací email na adresu: %(email)s "
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr "Zaslali jsme Vám potvrzovací email, prosím, klikněte na link uvnitř."
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr "Žádný adresát"
 
@@ -1863,6 +1883,11 @@ msgstr "Vaše jméno <small>Toto bude zveřejněno zde.</small>"
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr "Váš email <small>Toto nikdo nikdy neuvidí.</small>"
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
+msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34
 msgid "Go to home page"

--- a/locale/cs/LC_MESSAGES/djangojs.po
+++ b/locale/cs/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/cs_CZ/LC_MESSAGES/django.po
+++ b/locale/cs_CZ/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Czech (Czech Republic) (http://www.transifex.com/mysociety/writeinpublic/language/cs_CZ/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -103,11 +103,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -116,12 +116,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -255,9 +255,9 @@ msgstr ""
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr ""
 
@@ -352,7 +352,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr ""
 
@@ -386,47 +386,49 @@ msgid "No results found."
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -440,7 +442,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -483,14 +485,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -545,7 +547,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -573,79 +575,79 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -660,45 +662,45 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -707,74 +709,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1375,8 +1377,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1528,48 +1530,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr ""
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1599,19 +1601,19 @@ msgstr ""
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr ""
 
@@ -1622,7 +1624,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1639,7 +1641,7 @@ msgstr ""
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1649,17 +1651,17 @@ msgstr[2] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr ""
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr ""
@@ -1680,35 +1682,35 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1772,8 +1774,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr ""
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1788,7 +1790,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1870,15 +1872,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr ""
 

--- a/locale/cs_CZ/LC_MESSAGES/django.po
+++ b/locale/cs_CZ/LC_MESSAGES/django.po
@@ -94,7 +94,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1716,6 +1721,16 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1747,8 +1762,13 @@ msgstr ""
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr ""
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr ""
 
@@ -1860,6 +1880,11 @@ msgstr ""
 
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
+msgstr ""
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
 msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34

--- a/locale/cs_CZ/LC_MESSAGES/djangojs.po
+++ b/locale/cs_CZ/LC_MESSAGES/djangojs.po
@@ -10,12 +10,12 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-27 04:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language-Team: Czech (Czech Republic) (https://www.transifex.com/mysociety/teams/63717/cs_CZ/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: cs_CZ\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: nuntium/static/js/who.js:18
 #, c-format

--- a/locale/cs_CZ/LC_MESSAGES/djangojs.po
+++ b/locale/cs_CZ/LC_MESSAGES/djangojs.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-27 08:27-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -93,7 +93,12 @@ msgid_plural "You can send messages to at most %(count)d people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1706,6 +1711,16 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1737,8 +1752,13 @@ msgstr ""
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr ""
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr ""
 
@@ -1849,6 +1869,11 @@ msgstr ""
 
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
+msgstr ""
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
 msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-27 08:27-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -102,11 +102,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -115,12 +115,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -254,9 +254,9 @@ msgstr ""
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr ""
 
@@ -351,7 +351,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr ""
 
@@ -385,47 +385,49 @@ msgid "No results found."
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -438,7 +440,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -481,14 +483,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -542,7 +544,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -570,79 +572,79 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -656,45 +658,45 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -703,74 +705,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1367,8 +1369,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1520,48 +1522,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr ""
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1591,19 +1593,19 @@ msgstr ""
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr ""
 
@@ -1614,7 +1616,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1631,7 +1633,7 @@ msgstr ""
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1640,17 +1642,17 @@ msgstr[1] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr ""
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr ""
@@ -1671,35 +1673,35 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1762,8 +1764,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr ""
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1777,7 +1779,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1859,15 +1861,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/mysociety/writeinpublic/language/es/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -102,11 +102,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -115,12 +115,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -254,9 +254,9 @@ msgstr "Salir"
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr ""
 
@@ -351,7 +351,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr ""
 
@@ -385,47 +385,49 @@ msgid "No results found."
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -438,7 +440,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -481,14 +483,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -542,7 +544,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -570,79 +572,79 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -656,45 +658,45 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -703,74 +705,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1367,8 +1369,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1520,48 +1522,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr ""
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1591,19 +1593,19 @@ msgstr ""
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr ""
 
@@ -1614,7 +1616,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1631,7 +1633,7 @@ msgstr ""
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1640,17 +1642,17 @@ msgstr[1] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr ""
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr ""
@@ -1671,35 +1673,35 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1762,8 +1764,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr ""
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1777,7 +1779,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1859,15 +1861,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -93,7 +93,12 @@ msgid_plural "You can send messages to at most %(count)d people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1706,6 +1711,16 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1737,8 +1752,13 @@ msgstr ""
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr ""
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr ""
 
@@ -1849,6 +1869,11 @@ msgstr ""
 
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
+msgstr ""
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
 msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -93,7 +93,12 @@ msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
 msgstr[0] "این نامه می‌تواند حداکثر به %(count)d نفر فرستاده شود"
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr "ما اطلاعات تماس این افراد را در اختیار نداریم: {list_of_names}"
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr "ذکر نام نویسنده ضروری است. "
 
@@ -1561,7 +1566,9 @@ msgid ""
 "\n"
 "                Reply from %(name)s\n"
 "            "
-msgstr "\nپاسخ نامه از طرف %(name)s"
+msgstr ""
+"\n"
+"پاسخ نامه از طرف %(name)s"
 
 #: nuntium/templates/thread/read.html:15
 #: writeit/templates/subdomains/infoszab/thread/read.html:15
@@ -1701,6 +1708,16 @@ msgstr[0] ""
 "\n"
 "می‌خواهم گیرندگان نامه را تغییر دهم"
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr "برای اطلاعات تماس برخی از نمایندگان می‌توانید به ما یاری برسانید. "
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr "ما نشانی اینترنتی (ایمیل) افراد فهرست زیر را در اختیار نداریم. اگر ایمیل هر کدام از آنها را می‌دانید، لطفا از طریق فرم مقابل با ما تماس بگیرید:"
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1734,8 +1751,13 @@ msgstr "ما یک ایمیل تایید فرستادیم به %(email)s"
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr "یک لینک تایید برای شما ایمیل کردیم. لطفا روی آن کلیک کنید."
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr "(اطلاعات تماس را در اختیار نداریم.)"
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr "نام گیرنده موجود نیست. "
 
@@ -1850,6 +1872,11 @@ msgstr " نام؛ <small>  نام شما در وبسایت منتشر خواهد
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr " ایمیل؛ <small> هرگز کسی ایمیل شما را نخواهد دید </small>"
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
+msgstr "ما نشانی اینترنتی (ایمیل) افراد فهرست زیر را در اختیار نداریم. اگر ایمیل هر کدام از آنها را می‌دانید، لطفا از طریق ایمیل مقابل با ما تماس بگیرید :%(email)s"
 
 #: writeit/templates/subdomains/iran/write/sign.html:34
 msgid "Go to home page"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-14 23:01+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Persian (http://www.transifex.com/mysociety/writeinpublic/language/fa/)\n"
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr "نویسنده‌‌ی نامه‌ها می‌توانند ذکر نشوند. "
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -87,7 +87,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -102,11 +102,11 @@ msgstr "ما اطلاعات تماس این افراد را در اختیار ن
 msgid "Author name is required"
 msgstr "ذکر نام نویسنده ضروری است. "
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -115,12 +115,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr "شما به حداکثر ظرفیت امروز خود رسیدید، لطفاً فراد مجدداً تلاش نمایید. "
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr "ناشناس"
 
@@ -128,7 +128,7 @@ msgstr "ناشناس"
 msgid "A message needs persons to be sent"
 msgstr "نامه‌ها باید به کسی منسوب شوند تا ارسال شوند. "
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr "این نامه اول باید به تأیید برسد. "
 
@@ -254,9 +254,9 @@ msgstr "خروج"
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr "در حال حاضر نمی‌توانید پیام تازه‌ای بنویسید."
 
@@ -351,7 +351,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr "تازه‌ترین نامه‌ها"
 
@@ -385,47 +385,49 @@ msgid "No results found."
 msgstr "نتیجه‌ای یافت نشد."
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr "نامه‌های فرستاده شده توسط %(author_name)s "
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr "در حال حاضر هیچ پیام عمومی‌ای در این وبسایت نیست. "
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr "تمام نامه‌های فرستاده شده به %(person_name)s "
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr "پاسخ‌ها "
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr "بازگشت به پاسخ‌ها"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr "هنوز پاسخی موجود نیست"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -437,7 +439,7 @@ msgid_plural ""
 "            "
 msgstr[0] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -480,14 +482,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr "گیرندگان نامه"
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -540,7 +542,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -568,79 +570,79 @@ msgstr "API"
 msgid "Stats"
 msgstr "آمار"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr "موضوع"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr "نویسنده"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr "تایید شد"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr "مرور و تایید شده"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr "این پیام هنوز مرور نشده است - برای تایید اینجا کلیک کنید"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr "تایید"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr "لینک"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr "صفحه عمومی"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr "تاریخ نوشته"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr "محتوا"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr "نوشتن پاسخ"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr "ویرایش پاسخ"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -653,45 +655,45 @@ msgid_plural ""
 "    "
 msgstr[0] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr "پاسخ‌ها"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr "عمومی؟"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr "تایید شده؟"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr "مرور شده؟"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr "عمومی/خصوصی شود"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr "پیوند به ادمین پیام‌ها"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -700,74 +702,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr "اضافه کردن"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr "این پیام را همه می‌توانند ببینند. "
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr "نویسنده تایید کرده است که این پیام با ایمیل‌اش فرستاده شده است."
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr "نویسنده هنوز آدرس ایمیل خود را تایید نکرده است. "
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr "این پیام پذیرفته نشد."
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr "این پیام هنوز مرور نشده است."
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr "این پیام خصوصی است. برای عمومی کردن اینجا کلیک کنید.  "
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr "هیچ پیامی ندارید."
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr "این پیام پاک شود؟"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr "آیا مطمئنید که می‌خواهید این پیام را پاک کنید. این بازگشت‌پذیر نخواهد بود."
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1362,8 +1364,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1515,48 +1517,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr "از طرف"
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr "مشاهده تمام نامه‌های خطاب به %(name)s"
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr "تاریخ"
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr "خطاب به"
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr "مشاهده تمام نامه‌ها از طرف %(name)s"
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr "گیرندگان آدرس ایمیل شما را نخواهند دید. "
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr "خطاب به"
 
@@ -1588,19 +1590,19 @@ msgstr "اگر پاسخی دریافت کنیم به شما اطلاع خواه�
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr "نامه‌ی شما و هر پاسخ احتمالی به آن، روی وبسایت نمایش داده خواهد شد و برای همه قابل رویت خواهد بود."
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr "پاسخ‌ها اینجا منتشر خواهند شد."
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr "بازگشت به همه نامه‌ها"
 
@@ -1611,7 +1613,7 @@ msgstr "این نامه پیش از نمایش احتیاج به مدیریت د
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1628,7 +1630,7 @@ msgstr "به این شخص نامه بنویسید."
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] "گیرندگان نامه‌ را انتخاب کنید"
@@ -1636,17 +1638,17 @@ msgstr[0] "گیرندگان نامه‌ را انتخاب کنید"
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr "پیش‌نویس نامه"
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr "مرور نامه"
@@ -1667,35 +1669,35 @@ msgstr "نامه فرستاده شد"
 msgid "Send message"
 msgstr "ارسال نامه"
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr "نامه شما"
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr "این در وبسایت منتشر خواهد شد"
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr "نام"
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr "ایمیل"
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr "هرگز کسی ایمیل شما را نخواهد دید"
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1761,8 +1763,8 @@ msgstr "(اطلاعات تماس را در اختیار نداریم.)"
 msgid "No recipients match"
 msgstr "نام گیرنده موجود نیست. "
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1779,7 +1781,7 @@ msgstr[0] ""
 "<br/ ><br />\n"
 "شما می‌توانید نامه‌ی خود را به حداکثر %(counter)s نفر بفرستید."
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1861,15 +1863,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr " ارادتمند شما، <br> %(author_name)s "
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr " متن نامه؛ <small> این متن در وبسایت منتشر خواهد شد </small>"
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr " نام؛ <small>  نام شما در وبسایت منتشر خواهد شد </small>"
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr " ایمیل؛ <small> هرگز کسی ایمیل شما را نخواهد دید </small>"
 

--- a/locale/fa/LC_MESSAGES/djangojs.po
+++ b/locale/fa/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/fa/LC_MESSAGES/djangojs.po
+++ b/locale/fa/LC_MESSAGES/djangojs.po
@@ -21,8 +21,8 @@ msgstr ""
 #: nuntium/static/js/who.js:18
 #, c-format
 msgid "We do not have contact details for %s."
-msgstr ""
+msgstr "ما اطلاعات تماس با %s را فعلاً در اختیار نداریم. "
 
 #: nuntium/static/js/who.js:21
 msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
-msgstr ""
+msgstr "%(open_danger_tag)s این فرد را حذف کرده %(close_tag)s یا %(open_default_tag)s اطلاعات تماس نماینده را در صورتی که می‌توانید، در اختیار ما قرار دهید. %(close_tag)s"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: French (http://www.transifex.com/mysociety/writeinpublic/language/fr/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -102,11 +102,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -115,12 +115,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -254,9 +254,9 @@ msgstr ""
 msgid "This site is read-only."
 msgstr ""
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr ""
 
@@ -351,7 +351,7 @@ msgstr ""
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr ""
 
@@ -385,47 +385,49 @@ msgid "No results found."
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -438,7 +440,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -481,14 +483,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -542,7 +544,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -570,79 +572,79 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -656,45 +658,45 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -703,74 +705,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1367,8 +1369,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1520,48 +1522,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr ""
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr ""
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1591,19 +1593,19 @@ msgstr ""
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr ""
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr ""
 
@@ -1614,7 +1616,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1631,7 +1633,7 @@ msgstr ""
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] ""
@@ -1640,17 +1642,17 @@ msgstr[1] ""
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr ""
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr ""
@@ -1671,35 +1673,35 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr ""
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr ""
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1762,8 +1764,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr ""
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1777,7 +1779,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1859,15 +1861,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -93,7 +93,12 @@ msgid_plural "You can send messages to at most %(count)d people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1706,6 +1711,16 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1737,8 +1752,13 @@ msgstr ""
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr ""
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr ""
 
@@ -1849,6 +1869,11 @@ msgstr ""
 
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
+msgstr ""
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
 msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: writeinpublic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-19 11:49-0500\n"
+"POT-Creation-Date: 2016-09-28 03:12-0500\n"
 "PO-Revision-Date: 2016-09-07 11:42+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: Hungarian (http://www.transifex.com/mysociety/writeinpublic/language/hu/)\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Messages can have empty Author             names"
 msgstr ""
 
-#: mailit/forms.py:13 nuntium/forms.py:55
+#: mailit/forms.py:13 nuntium/forms.py:73
 msgid "Instance not present"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "You can use {subject}, {content}, {person}, {author}, {site_url}, {site_name}, and {owner_email}"
 msgstr ""
 
-#: nuntium/forms.py:83
+#: nuntium/forms.py:101
 #, python-format
 msgid "You can send messages to at most %(count)d person"
 msgid_plural "You can send messages to at most %(count)d people"
@@ -102,11 +102,11 @@ msgstr ""
 msgid "Author name is required"
 msgstr ""
 
-#: nuntium/forms.py:174 nuntium/user_section/forms.py:281
+#: nuntium/forms.py:205 nuntium/user_section/forms.py:281
 msgid "Popolo URL"
 msgstr ""
 
-#: nuntium/forms.py:175 nuntium/user_section/forms.py:282
+#: nuntium/forms.py:206 nuntium/user_section/forms.py:282
 msgid "Example: https://cdn.rawgit.com/everypolitician/everypolitician-data/1460373/data/Abkhazia/Assembly/ep-popolo-v1.0.json"
 msgstr ""
 
@@ -115,12 +115,12 @@ msgstr ""
 msgid "The message \"%(subject)s\" at %(instance)s turned %(status)s at %(date)s"
 msgstr ""
 
-#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:236
+#: nuntium/models.py:143 nuntium/tests/message_form_tests.py:275
 #: nuntium/tests/rate_limiter_tests.py:148
 msgid "You have reached your limit for today please try again tomorrow"
 msgstr ""
 
-#: nuntium/models.py:183 nuntium/templates/thread/message.html:28
+#: nuntium/models.py:183 nuntium/templates/thread/message.html:31
 msgid "Anonymous"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "A message needs persons to be sent"
 msgstr ""
 
-#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:139
+#: nuntium/models.py:262 nuntium/tests/moderation_messages_test.py:208
 msgid "The message needs to be confirmated first"
 msgstr ""
 
@@ -254,9 +254,9 @@ msgstr "Kilépés"
 msgid "This site is read-only."
 msgstr "Ezen az oldalon nem lehet változtatásokat eszközölni."
 
-#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:47
+#: nuntium/templates/base_instance.html:99 nuntium/templates/write/who.html:68
 #: writeit/templates/subdomains/iran/base_instance.html:37
-#: writeit/templates/subdomains/iran/write/who.html:63
+#: writeit/templates/subdomains/iran/write/who.html:85
 msgid "You can’t currently create new messages using this site."
 msgstr "Jelenleg nem lehet új üzeneteket küldeni az oldal segítségével."
 
@@ -351,7 +351,7 @@ msgstr "Írjon azoknak, akik képviselik! <br /> Kérjen tőlük válaszokat nyi
 #: nuntium/templates/nuntium/instance_detail.html:28
 #: writeit/templates/subdomains/infoszab/nuntium/instance_detail.html:24
 #: writeit/templates/subdomains/iran/index.html:82
-#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:11
+#: writeit/templates/subdomains/iran/nuntium/instance_detail.html:13
 msgid "Recent messages"
 msgstr "Legutóbbi üzenetek"
 
@@ -385,47 +385,49 @@ msgid "No results found."
 msgstr "Nincs találat"
 
 #: nuntium/templates/nuntium/message/from_person.html:6
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:10
 #, python-format
 msgid "Messages sent by %(author_name)s "
 msgstr ""
 
 #: nuntium/templates/nuntium/message/from_person.html:13
 #: nuntium/templates/thread/all.html:17
+#: writeit/templates/subdomains/iran/nuntium/message/from_person.html:17
 #: writeit/templates/subdomains/iran/thread/all.html:23
 msgid "There are currently no public messages on this site."
 msgstr "Még nincsenek nyilvános üzenetek az oldalon."
 
-#: nuntium/templates/nuntium/message/message_detail.html:13
+#: nuntium/templates/nuntium/message/message_detail.html:17
 msgid "This message was sent to"
 msgstr ""
 
-#: nuntium/templates/nuntium/message/message_detail.html:16
-#: nuntium/templates/nuntium/message/message_in_list.html:28
-#: nuntium/templates/nuntium/profiles/message_detail.html:26
+#: nuntium/templates/nuntium/message/message_detail.html:20
+#: nuntium/templates/nuntium/message/message_in_list.html:31
+#: nuntium/templates/nuntium/profiles/message_detail.html:28
 #, python-format
 msgid "See all messages sent to %(person_name)s"
 msgstr "Mutassa az összes üzenetet tőle: %(person_name)s"
 
-#: nuntium/templates/nuntium/message/message_detail.html:22
+#: nuntium/templates/nuntium/message/message_detail.html:26
 #, python-format
 msgid ""
 "Asked by \n"
 "    <a href=\"%(other_messages_by)s\">%(name)s</a>."
 msgstr "<a href=\"%(other_messages_by)s\">%(name)s</a> kérdése"
 
-#: nuntium/templates/nuntium/message/message_detail.html:40
+#: nuntium/templates/nuntium/message/message_detail.html:44
 msgid "Answers"
 msgstr "Válaszok"
 
-#: nuntium/templates/nuntium/message/message_detail.html:47
+#: nuntium/templates/nuntium/message/message_detail.html:51
 msgid " Get back to the messages."
 msgstr "Vissza az üzenetekhez"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:13
+#: nuntium/templates/nuntium/message/message_in_list.html:16
 msgid "There are no answers yet"
 msgstr "Még nem érkezett válasz"
 
-#: nuntium/templates/nuntium/message/message_in_list.html:15
+#: nuntium/templates/nuntium/message/message_in_list.html:18
 #, python-format
 msgid ""
 "\n"
@@ -438,7 +440,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/message/message_in_list.html:34
+#: nuntium/templates/nuntium/message/message_in_list.html:37
 #, python-format
 msgid ""
 "Asked by \n"
@@ -481,14 +483,14 @@ msgstr ""
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:36
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:11
-#: nuntium/templates/nuntium/profiles/message_detail.html:24
+#: nuntium/templates/nuntium/profiles/message_detail.html:26
 #: nuntium/templates/nuntium/profiles/your-instances.html:22
 #: nuntium/templates/nuntium/profiles/your-instances.html:85
 msgid "Recipients"
 msgstr "Címzettek"
 
 #: nuntium/templates/nuntium/profiles/contacts/contacts-per-writeitinstance.html:39
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:25
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:24
 #: nuntium/templates/nuntium/writeitinstance_api_docs.html:8
 msgid "Settings"
@@ -542,7 +544,7 @@ msgid "About your site"
 msgstr ""
 
 #: nuntium/templates/nuntium/profiles/manager-navigation.html:17
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:23
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:24
 #: nuntium/templates/nuntium/profiles/your-instances.html:23
 #: nuntium/templates/nuntium/profiles/your-instances.html:86
 msgid "Messages"
@@ -570,79 +572,79 @@ msgstr "API"
 msgid "Stats"
 msgstr "Statisztika"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:20
-#: nuntium/templates/thread/message.html:36
-#: nuntium/templates/write/draft.html:17
-#: writeit/templates/subdomains/infoszab/write/draft.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:30
-#: writeit/templates/subdomains/iran/write/draft.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/thread/message.html:39
+#: nuntium/templates/write/draft.html:19
+#: writeit/templates/subdomains/infoszab/write/draft.html:20
+#: writeit/templates/subdomains/iran/thread/message.html:32
+#: writeit/templates/subdomains/iran/write/draft.html:24
 msgid "Subject"
 msgstr "Tárgy"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:22
+#: nuntium/templates/nuntium/profiles/message_detail.html:24
 msgid "Author"
 msgstr "Szerző"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:28
+#: nuntium/templates/nuntium/profiles/message_detail.html:30
 msgid "Confirmed"
 msgstr "Jóváhagyva"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:32
+#: nuntium/templates/nuntium/profiles/message_detail.html:34
 msgid "Moderated"
 msgstr "Moderálva"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "This message has not yet been moderated — click here to accept it"
 msgstr "Ez az üzenet még nem lett jóváhagyva, kattintson ide az elfogadásához"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:37
+#: nuntium/templates/nuntium/profiles/message_detail.html:39
 msgid "Accept"
 msgstr "Jóváhagyom"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "This message has not yet been moderated — click here to reject it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:39
+#: nuntium/templates/nuntium/profiles/message_detail.html:41
 msgid "Reject"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:46
+#: nuntium/templates/nuntium/profiles/message_detail.html:48
 msgid "Link"
 msgstr "Link"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:47
+#: nuntium/templates/nuntium/profiles/message_detail.html:49
 msgid "Public page"
 msgstr "Nyilvános oldal"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:49
+#: nuntium/templates/nuntium/profiles/message_detail.html:51
 msgid "Creation Date"
 msgstr "Létrehozás dátuma"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:51
-#: nuntium/templates/nuntium/profiles/message_detail.html:67
+#: nuntium/templates/nuntium/profiles/message_detail.html:53
+#: nuntium/templates/nuntium/profiles/message_detail.html:69
 msgid "Content"
 msgstr "Tartalom"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:57
+#: nuntium/templates/nuntium/profiles/message_detail.html:59
 msgid "Create a reply"
 msgstr "Válasz hozzáadása"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:66
+#: nuntium/templates/nuntium/profiles/message_detail.html:68
 msgid "Person"
 msgstr "Személy"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:68
-#: nuntium/templates/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:44
+#: nuntium/templates/nuntium/profiles/message_detail.html:70
+#: nuntium/templates/thread/read.html:53
+#: writeit/templates/subdomains/iran/thread/read.html:48
 msgid "Actions"
 msgstr "Opciók"
 
-#: nuntium/templates/nuntium/profiles/message_detail.html:74
+#: nuntium/templates/nuntium/profiles/message_detail.html:76
 msgid "Edit reply"
 msgstr "Válasz szerkesztése"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:27
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:28
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:27
 #, python-format
 msgid ""
@@ -656,45 +658,45 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:38
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:38
 msgid "Message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:39
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:39
 msgid "Thread"
 msgstr "Levélfolyam"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:40
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:40
 msgid "Replies"
 msgstr "Válaszok"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:41
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:41
 msgid "Public?"
 msgstr "Nyilvános?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:42
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:43
 msgid "Confirmed?"
 msgstr "Jóváhagyva?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:44
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:45
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:42
 msgid "Moderated?"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:46
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:47
 msgid "Make private/public"
 msgstr "Beállítás nyilvánosra/rejtettre"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:53
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:54
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:49
 msgid "Link to message admin"
 msgstr "Admin üzenet linkje"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:56
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:57
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:52
 #, python-format
 msgid ""
@@ -703,74 +705,74 @@ msgid ""
 "                "
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:65
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:66
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:61
 msgid "Link to public message"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:73
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:74
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:69
 #: nuntium/templates/nuntium/profiles/webhooks.html:68
 #: nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html:83
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:79
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:80
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:75
 msgid "This message can be seen by everyone"
 msgstr "Ezt az üzenetet bárki láthatja"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:83
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:84
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:79
 msgid "This message can't be seen by anyone"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:91
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:92
 msgid "The author has confirmed that this was sent from their email"
 msgstr "A szerző megerősítette, hogy az ő e-mailjéről érkezett az üzenet"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:95
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:96
 msgid "The author has not yet confirmed their email address"
 msgstr "A szerző még nem erősítette meg az e-mail címét"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:104
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:105
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:87
 msgid "This message has been accepted"
 msgstr "Üzenet elfogadva"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:108
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:109
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:91
 msgid "This message has not yet been moderated"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:115
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:116
 msgid "This message is public, you can make it private by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:121
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:122
 msgid "This message is private, you can make it public by clicking here"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:131
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:132
 msgid "You have no messages"
 msgstr "Nincsen üzenet"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:142
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:143
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:108
 msgid "Delete this message?"
 msgstr "Üzenet törlése?"
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:145
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:146
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:111
 msgid "Are you sure you want to delete this message? This can't be undone."
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:148
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:114
 msgid "No, keep it"
 msgstr ""
 
-#: nuntium/templates/nuntium/profiles/messages_per_instance.html:149
+#: nuntium/templates/nuntium/profiles/messages_per_instance.html:150
 #: nuntium/templates/nuntium/profiles/moderation_queue.html:115
 msgid "Yes, delete it"
 msgstr ""
@@ -1369,8 +1371,8 @@ msgstr ""
 
 #: nuntium/templates/registration/login.html:23
 #: nuntium/templates/registration/signup.html:20
-#: nuntium/templates/write/who.html:46
-#: writeit/templates/subdomains/iran/write/who.html:62
+#: nuntium/templates/write/who.html:67
+#: writeit/templates/subdomains/iran/write/who.html:84
 msgid "Sorry"
 msgstr ""
 
@@ -1522,48 +1524,48 @@ msgstr ""
 msgid "Search messages"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:8
-#: nuntium/templates/thread/message.html:19
-#: writeit/templates/subdomains/iran/thread/answer.html:7
-#: writeit/templates/subdomains/iran/thread/message.html:18
+#: nuntium/templates/thread/answer.html:10
+#: nuntium/templates/thread/message.html:22
+#: writeit/templates/subdomains/iran/thread/answer.html:9
+#: writeit/templates/subdomains/iran/thread/message.html:20
 msgid "From"
 msgstr ""
 
-#: nuntium/templates/thread/answer.html:12
-#: nuntium/templates/thread/message.html:10
-#: writeit/templates/subdomains/iran/thread/answer.html:10
-#: writeit/templates/subdomains/iran/thread/message.html:9
+#: nuntium/templates/thread/answer.html:14
+#: nuntium/templates/thread/message.html:13
+#: writeit/templates/subdomains/iran/thread/answer.html:12
+#: writeit/templates/subdomains/iran/thread/message.html:11
 #, python-format
 msgid "Show all messages to %(name)s"
 msgstr "Mutassa a %(name)s részére küldött üzeneteket"
 
-#: nuntium/templates/thread/answer.html:20
-#: nuntium/templates/thread/message.html:40
-#: writeit/templates/subdomains/iran/thread/answer.html:17
-#: writeit/templates/subdomains/iran/thread/message.html:33
+#: nuntium/templates/thread/answer.html:22
+#: nuntium/templates/thread/message.html:43
+#: writeit/templates/subdomains/iran/thread/answer.html:19
+#: writeit/templates/subdomains/iran/thread/message.html:35
 msgid "Date"
 msgstr "Dátum"
 
-#: nuntium/templates/thread/message.html:6
-#: nuntium/templates/write/draft.html:13
-#: writeit/templates/subdomains/infoszab/write/draft.html:13
-#: writeit/templates/subdomains/iran/thread/message.html:6
-#: writeit/templates/subdomains/iran/write/draft.html:18
+#: nuntium/templates/thread/message.html:9
+#: nuntium/templates/write/draft.html:15
+#: writeit/templates/subdomains/infoszab/write/draft.html:16
+#: writeit/templates/subdomains/iran/thread/message.html:8
+#: writeit/templates/subdomains/iran/write/draft.html:20
 msgid "To"
 msgstr "Címzett"
 
-#: nuntium/templates/thread/message.html:23
-#: writeit/templates/subdomains/iran/thread/message.html:20
+#: nuntium/templates/thread/message.html:26
+#: writeit/templates/subdomains/iran/thread/message.html:22
 #, python-format
 msgid "Show all messages from %(name)s"
 msgstr "Mutassa %(name)s összes válaszát"
 
-#: nuntium/templates/thread/message.html:32
-#: writeit/templates/subdomains/iran/thread/message.html:26
+#: nuntium/templates/thread/message.html:35
+#: writeit/templates/subdomains/iran/thread/message.html:28
 msgid "Recipients will not see your email address"
 msgstr "A címzett nem fogja látni az Ön e-mail címét"
 
-#: nuntium/templates/thread/message_mini.html:6
+#: nuntium/templates/thread/message_mini.html:9
 msgid "To:"
 msgstr ""
 
@@ -1593,19 +1595,19 @@ msgstr "Ha válasz érkezik, azonnal értesítőt küldünk."
 msgid "We’ve published it too: your letter and any replies will be visible to everyone, on this page."
 msgstr "Az üzenetet közzétettük, a levél és az arra érkező válaszok nyilvánosan elérhetők lesznek ezen az oldalon."
 
-#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:45
+#: nuntium/templates/thread/read.html:21 nuntium/templates/thread/read.html:48
 #: writeit/templates/subdomains/infoszab/thread/read.html:21
 #: writeit/templates/subdomains/infoszab/thread/read.html:41
 #: writeit/templates/subdomains/iran/thread/read.html:23
-#: writeit/templates/subdomains/iran/thread/read.html:40
+#: writeit/templates/subdomains/iran/thread/read.html:43
 msgid "Future replies will be published here."
 msgstr "A válaszokat itt tesszük majd közzé."
 
-#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:51
+#: nuntium/templates/thread/read.html:24 nuntium/templates/thread/read.html:55
 #: writeit/templates/subdomains/infoszab/thread/read.html:24
 #: writeit/templates/subdomains/infoszab/thread/read.html:47
 #: writeit/templates/subdomains/iran/thread/read.html:26
-#: writeit/templates/subdomains/iran/thread/read.html:46
+#: writeit/templates/subdomains/iran/thread/read.html:50
 msgid "Back to all messages"
 msgstr "Vissz az összes üzenethez"
 
@@ -1616,7 +1618,7 @@ msgstr ""
 
 #: nuntium/templates/thread/read.html:57
 #: writeit/templates/subdomains/infoszab/thread/read.html:49
-#: writeit/templates/subdomains/iran/thread/read.html:48
+#: writeit/templates/subdomains/iran/thread/read.html:52
 msgid "Report for abuse"
 msgstr ""
 
@@ -1633,7 +1635,7 @@ msgstr "Írjon neki!"
 #: nuntium/templates/write/breadcrumb.html:7
 #: nuntium/templates/write/breadcrumb.html:16
 #: nuntium/templates/write/breadcrumb.html:24
-#: writeit/templates/subdomains/iran/write/who.html:35
+#: writeit/templates/subdomains/iran/write/who.html:57
 msgid "Select recipient"
 msgid_plural "Select recipients"
 msgstr[0] "Címzett kiválasztása"
@@ -1642,17 +1644,17 @@ msgstr[1] "Címzett kiválasztása"
 #: nuntium/templates/write/breadcrumb.html:33
 #: nuntium/templates/write/breadcrumb.html:35
 #: nuntium/templates/write/breadcrumb.html:37
-#: nuntium/templates/write/who.html:41
-#: writeit/templates/subdomains/iran/write/who.html:56
+#: nuntium/templates/write/who.html:62
+#: writeit/templates/subdomains/iran/write/who.html:78
 msgid "Draft message"
 msgstr "Üzenet írása"
 
 #: nuntium/templates/write/breadcrumb.html:41
 #: nuntium/templates/write/breadcrumb.html:43
 #: nuntium/templates/write/breadcrumb.html:45
-#: nuntium/templates/write/draft.html:61
-#: writeit/templates/subdomains/infoszab/write/draft.html:61
-#: writeit/templates/subdomains/iran/write/draft.html:63
+#: nuntium/templates/write/draft.html:63
+#: writeit/templates/subdomains/infoszab/write/draft.html:64
+#: writeit/templates/subdomains/iran/write/draft.html:65
 #: writeit/templates/subdomains/iran/write/preview.html:16
 msgid "Preview message"
 msgstr "Előnézet"
@@ -1673,35 +1675,35 @@ msgstr "Elküldtük"
 msgid "Send message"
 msgstr "Üzenek"
 
-#: nuntium/templates/write/draft.html:23
-#: writeit/templates/subdomains/infoszab/write/draft.html:23
+#: nuntium/templates/write/draft.html:25
+#: writeit/templates/subdomains/infoszab/write/draft.html:26
 msgid "Your message"
 msgstr "Üzenetem"
 
-#: nuntium/templates/write/draft.html:24 nuntium/templates/write/draft.html:35
-#: writeit/templates/subdomains/infoszab/write/draft.html:24
-#: writeit/templates/subdomains/infoszab/write/draft.html:35
+#: nuntium/templates/write/draft.html:26 nuntium/templates/write/draft.html:37
+#: writeit/templates/subdomains/infoszab/write/draft.html:27
+#: writeit/templates/subdomains/infoszab/write/draft.html:38
 msgid "This will be published, on this site."
 msgstr "Ez megjelenik az oldalon."
 
-#: nuntium/templates/write/draft.html:34
-#: writeit/templates/subdomains/infoszab/write/draft.html:34
+#: nuntium/templates/write/draft.html:36
+#: writeit/templates/subdomains/infoszab/write/draft.html:37
 msgid "Your name"
 msgstr "Név"
 
-#: nuntium/templates/write/draft.html:44
-#: writeit/templates/subdomains/infoszab/write/draft.html:44
+#: nuntium/templates/write/draft.html:46
+#: writeit/templates/subdomains/infoszab/write/draft.html:47
 msgid "Your email"
 msgstr "E-mail cím"
 
-#: nuntium/templates/write/draft.html:45
-#: writeit/templates/subdomains/infoszab/write/draft.html:45
+#: nuntium/templates/write/draft.html:47
+#: writeit/templates/subdomains/infoszab/write/draft.html:48
 msgid "Nobody will see this, ever."
 msgstr "Ezt soha senkinek nem mutatjuk meg."
 
-#: nuntium/templates/write/draft.html:55
-#: writeit/templates/subdomains/infoszab/write/draft.html:55
-#: writeit/templates/subdomains/iran/write/draft.html:57
+#: nuntium/templates/write/draft.html:57
+#: writeit/templates/subdomains/infoszab/write/draft.html:58
+#: writeit/templates/subdomains/iran/write/draft.html:59
 msgid ""
 "\n"
 "                    Change recipient\n"
@@ -1768,8 +1770,8 @@ msgstr ""
 msgid "No recipients match"
 msgstr "Nincs ilyen címzett"
 
-#: nuntium/templates/write/who.html:29
-#: writeit/templates/subdomains/iran/write/who.html:44
+#: nuntium/templates/write/who.html:50
+#: writeit/templates/subdomains/iran/write/who.html:66
 #, python-format
 msgid ""
 "\n"
@@ -1783,7 +1785,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/templatetags/nuntium_tags.py:58
+#: nuntium/templatetags/nuntium_tags.py:71
 msgid "Invalid subdomain for custom CSS"
 msgstr ""
 
@@ -1865,15 +1867,15 @@ msgstr ""
 msgid "Yours sincerely, <br> %(author_name)s"
 msgstr ""
 
-#: writeit/templates/subdomains/iran/write/draft.html:28
+#: writeit/templates/subdomains/iran/write/draft.html:30
 msgid "Your message <small>This will be published, on this site.</small>"
 msgstr "Üzenetem <small>Ez megjelenik az oldalon.</small"
 
-#: writeit/templates/subdomains/iran/write/draft.html:38
+#: writeit/templates/subdomains/iran/write/draft.html:40
 msgid "Your name <small>This will be published, on this site.</small>"
 msgstr "Név <small>Ez megjelenik az oldalon.</small>"
 
-#: writeit/templates/subdomains/iran/write/draft.html:47
+#: writeit/templates/subdomains/iran/write/draft.html:49
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr "E-mail cím <small>Ezt soha senkinek nem mutatjuk meg.</small>"
 

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -93,7 +93,12 @@ msgid_plural "You can send messages to at most %(count)d people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: nuntium/forms.py:121
+#: nuntium/forms.py:128
+#, python-brace-format
+msgid "We have no contact details for the following people: {list_of_names}"
+msgstr ""
+
+#: nuntium/forms.py:152
 msgid "Author name is required"
 msgstr ""
 
@@ -1712,6 +1717,16 @@ msgstr[1] ""
 "\n"
 "Címzett megváltoztatása"
 
+#: nuntium/templates/write/missing_contacts.html:11
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:14
+msgctxt "Title of page appealing for help finding more contact details"
+msgid "Help to find missing contact details"
+msgstr ""
+
+#: nuntium/templates/write/missing_contacts.html:14
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us using the following form:"
+msgstr ""
+
 #: nuntium/templates/write/preview.html:14
 #: writeit/templates/subdomains/iran/write/preview.html:20
 msgid "Are you happy for this message to be made public?"
@@ -1743,8 +1758,13 @@ msgstr "A %(email)s címre kültünk egy üzenetet a megerősítéshez"
 msgid "We have emailed you a confirmation link. Please click it."
 msgstr "Küldtünk egy üzenetet a megerősítéshez, kérjük, a jóváhagyáshoz kattintson a linkre."
 
-#: nuntium/templates/write/who.html:12
-#: writeit/templates/subdomains/iran/write/who.html:12
+#: nuntium/templates/write/who.html:9
+#: writeit/templates/subdomains/iran/write/who.html:9
+msgid "(No contact details)"
+msgstr ""
+
+#: nuntium/templates/write/who.html:34
+#: writeit/templates/subdomains/iran/write/who.html:34
 msgid "No recipients match"
 msgstr "Nincs ilyen címzett"
 
@@ -1856,6 +1876,11 @@ msgstr "Név <small>Ez megjelenik az oldalon.</small>"
 #: writeit/templates/subdomains/iran/write/draft.html:47
 msgid "Your email <small>Nobody will see this, ever.</small>"
 msgstr "E-mail cím <small>Ezt soha senkinek nem mutatjuk meg.</small>"
+
+#: writeit/templates/subdomains/iran/write/missing_contacts.html:17
+#, python-format
+msgid "We don’t have an email address for any of the people listed below. If you know or can find the email addresses for any of them, please contact us at: %(email)s"
+msgstr ""
 
 #: writeit/templates/subdomains/iran/write/sign.html:34
 msgid "Go to home page"

--- a/locale/hu/LC_MESSAGES/djangojs.po
+++ b/locale/hu/LC_MESSAGES/djangojs.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-27 04:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: nuntium/static/js/who.js:18
+#, c-format
+msgid "We do not have contact details for %s."
+msgstr ""
+
+#: nuntium/static/js/who.js:21
+msgid "%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"
+msgstr ""

--- a/nuntium/forms.py
+++ b/nuntium/forms.py
@@ -5,7 +5,6 @@ from django.forms import ModelForm, ModelMultipleChoiceField, SelectMultiple, UR
 from instance.models import WriteItInstance
 from .models import Message, Confirmation
 
-from contactos.models import Contact
 from django.forms import ValidationError
 from django.utils.translation import ugettext as _, ungettext
 from popit.models import Person
@@ -16,11 +15,21 @@ from django.utils.safestring import mark_safe
 
 
 class PersonSelectMultipleWidget(SelectMultiple):
+
+    def __init__(self, *args, **kwargs):
+        person_queryset = kwargs.pop('person_queryset')
+        super(PersonSelectMultipleWidget, self).__init__(*args, **kwargs)
+        self.person_id_to_person = {
+            person.id: person
+            for person in person_queryset
+        }
+
     def render_option(self, selected_choices, option_value, option_label):
-        person = Person.objects.get(id=option_value)
-        contacts_exist = Contact.are_there_contacts_for(person)
-        if not contacts_exist:
-            option_label += u" *"
+        person = self.person_id_to_person[option_value]
+        css_class = 'uncontactable'
+        for contact in person.contact_set.all():
+            if not contact.is_bounced:
+                css_class = ''
         option_value = force_text(option_value)
         if option_value in selected_choices:
             selected_html = mark_safe(u' selected="selected"')
@@ -32,14 +41,22 @@ class PersonSelectMultipleWidget(SelectMultiple):
             #     selected_choices.remove(option_value)
         else:
             selected_html = ''
-        return format_html(u'<option value="{0}"{1}>{2}</option>',
+        return format_html(u'<option class="{0}" value="{1}"{2}>{3}</option>',
+                           css_class,
                            option_value,
                            selected_html,
                            force_text(option_label))
 
 
 class PersonMultipleChoiceField(ModelMultipleChoiceField):
-    widget = PersonSelectMultipleWidget(attrs={'class': 'chosen-person-select'})
+
+    def __init__(self, queryset, *args, **kwargs):
+        kwargs['widget'] = PersonSelectMultipleWidget(
+            person_queryset=queryset,
+            attrs={'class': 'chosen-person-select'}
+        )
+        super(PersonMultipleChoiceField, self).__init__(
+            queryset, *args, **kwargs)
 
     def label_from_instance(self, obj):
         return obj.name
@@ -94,11 +111,11 @@ class MessageCreateForm(ModelForm):
 
 
 class WhoForm(Form):
-    persons = PersonMultipleChoiceField(queryset=Person.objects.none())
 
     def __init__(self, persons_queryset, *args, **kwargs):
         super(WhoForm, self).__init__(*args, **kwargs)
-        self.fields['persons'].queryset = persons_queryset
+        self.fields['persons'] = \
+            PersonMultipleChoiceField(queryset=persons_queryset)
 
 
 class DraftForm(ModelForm):

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -20,7 +20,8 @@ $(function(){
     var choicesSentence = interpolate(
       gettext("%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"),
       {open_danger_tag: '<a class="btn btn-danger btn-sm js-deselect">',
-       open_default_tag: '<a class="btn btn-default btn-sm" href="http://example.com" target="_blank">',
+       open_default_tag: '<a class="btn btn-default btn-sm" href="' +
+       missingContactsURL + '" target="_blank">',
        close_tag: '</a>'},
       true);
     $warning.attr('role', 'alert');

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -1,5 +1,26 @@
 $(function(){
 
+  // Temporarily add the "uncontactable" class to a random selection
+  // of contacts in the person selector.
+  // TODO: This should be done in forms.py > PersonMultipleChoiceField
+  $('.chosen-person-select option').each(function(i){
+    if( Math.random(0, 1) <= 0.2 ){
+      $(this).addClass('uncontactable');
+    }
+  });
+
+  // Copy the "uncontactable" class from the original dropdown `<option>`s,
+  // onto the chosen.js dropdown `<li>`s.
+  $('.chosen-person-select').on('chosen:showing_dropdown', function(e, params){
+    var $options = $(params.chosen.dropdown[0]).find('li');
+    $options.each(function(i){
+      var originalOptElement = params.chosen.results_data[i];
+      if(originalOptElement.classes.indexOf('uncontactable') !== -1){
+        $(this).addClass('uncontactable');
+      }
+    });
+  });
+
   if(window.who.rtl) {
     $(".chosen-person-select").addClass('chosen-rtl');
   }
@@ -10,6 +31,6 @@ $(function(){
     placeholder_text_multiple: ' ', // hide placeholder text
     placeholder_text_single: ' ', // hide placeholder text
     single_backstroke_delete: false
-   });
+  });
 
 });

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -1,10 +1,10 @@
 $(function(){
 
-  // Temporarily add the "uncontactable" class to a random selection
-  // of contacts in the person selector.
+  // Temporarily add the "uncontactable" class to a people whose
+  // names end with a vowel (just an example!!).
   // TODO: This should be done in forms.py > PersonMultipleChoiceField
   $('.chosen-person-select option').each(function(i){
-    if( Math.random(0, 1) <= 0.2 ){
+    if( /[aeiou]$/.test( $(this).text() ) ){
       $(this).addClass('uncontactable');
     }
   });
@@ -19,6 +19,57 @@ $(function(){
         $(this).addClass('uncontactable');
       }
     });
+  });
+
+  var showUncontactableWarning = function showUncontactableWarning($selectedOption, $originalSelect, $chosenSelect){
+    var $warning = $('<div>').addClass('alert alert-danger uncontactable-alert');
+    $warning.attr('role', 'alert');
+    // TODO: i18n!!
+    $warning.html(
+      '<p>We do not have contact details for ' + $selectedOption.text() + '.</p>' +
+      '<p>' +
+      '<a class="btn btn-danger btn-sm js-deselect">Remove this recipient</a> ' +
+      '<span class="or">or</span> ' +
+      '<a class="btn btn-default btn-sm" href="http://example.com" target="_blank">Contribute new contact details</a>' +
+      '</p>'
+    );
+    $warning.insertAfter($chosenSelect);
+    $warning.on('click', '.js-deselect', function(){
+      $selectedOption.attr('selected', false);
+      // `chosen:updated` notifies chosen.js that the source <select> has changed.
+      // `change` notifies our change listener to update the styling and alerts.
+      $originalSelect.trigger('chosen:updated').trigger('change');
+    });
+  }
+
+  // Render the "uncontactable" styling and warning alerts whenever the
+  // selection is changed, or chosen.js loads with pre-selected options.
+  $('.chosen-person-select').on('change chosen:ready', function(e){
+      var $originalSelect = $(this);
+      var $chosenSelect = $originalSelect.next();
+
+      // Remove existing warnings (they'll get recreated if still required).
+      $('.uncontactable-alert').remove();
+
+      // Show warnings if the selected options include uncontactable people.
+      $('option:selected', $originalSelect).each(function(){
+        if( $(this).hasClass('uncontactable') ){
+          showUncontactableWarning(
+            $(this),
+            $originalSelect,
+            $chosenSelect
+          );
+        }
+      });
+
+      // Update the styling of the chosen.js tokens for uncontactable people.
+      $('.search-choice', $chosenSelect).each(function(){
+        var optionArrayIndex = $(this).children('a').attr('data-option-array-index');
+        var $originalOption = $originalSelect.find('option').eq(optionArrayIndex);
+        if( $originalOption.hasClass('uncontactable') ){
+          $(this).addClass('uncontactable');
+        }
+      });
   });
 
   if(window.who.rtl) {

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -1,14 +1,5 @@
 $(function(){
 
-  // Temporarily add the "uncontactable" class to a people whose
-  // names end with a vowel (just an example!!).
-  // TODO: This should be done in forms.py > PersonMultipleChoiceField
-  $('.chosen-person-select option').each(function(i){
-    if( /[aeiou]$/.test( $(this).text() ) ){
-      $(this).addClass('uncontactable');
-    }
-  });
-
   // Copy the "uncontactable" class from the original dropdown `<option>`s,
   // onto the chosen.js dropdown `<li>`s.
   $('.chosen-person-select').on('chosen:showing_dropdown', function(e, params){

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -78,4 +78,9 @@ $(function(){
     single_backstroke_delete: false
   });
 
+  // Hide the errror list - this only shows validation errors from
+  // people who are selected but for whom there are no contact
+  // details, and the Javascript already displays an error for them:
+  $('ul.errorlist').hide();
+
 });

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -1,0 +1,15 @@
+$(function(){
+
+  if(window.who.rtl) {
+    $(".chosen-person-select").addClass('chosen-rtl');
+  }
+  $(".chosen-person-select").chosen({
+    width: '100%',
+    max_selected_options: window.who.max_selected_options,
+    no_results_text: window.who.no_results_text,
+    placeholder_text_multiple: ' ', // hide placeholder text
+    placeholder_text_single: ' ', // hide placeholder text
+    single_backstroke_delete: false
+   });
+
+});

--- a/nuntium/static/js/who.js
+++ b/nuntium/static/js/who.js
@@ -14,15 +14,18 @@ $(function(){
 
   var showUncontactableWarning = function showUncontactableWarning($selectedOption, $originalSelect, $chosenSelect){
     var $warning = $('<div>').addClass('alert alert-danger uncontactable-alert');
+    var warningSentence = interpolate(
+      gettext("We do not have contact details for %s."),
+      [$selectedOption.text()]);
+    var choicesSentence = interpolate(
+      gettext("%(open_danger_tag)sRemove this recipient%(close_tag)s or %(open_default_tag)sContribute new contact details%(close_tag)s"),
+      {open_danger_tag: '<a class="btn btn-danger btn-sm js-deselect">',
+       open_default_tag: '<a class="btn btn-default btn-sm" href="http://example.com" target="_blank">',
+       close_tag: '</a>'},
+      true);
     $warning.attr('role', 'alert');
-    // TODO: i18n!!
     $warning.html(
-      '<p>We do not have contact details for ' + $selectedOption.text() + '.</p>' +
-      '<p>' +
-      '<a class="btn btn-danger btn-sm js-deselect">Remove this recipient</a> ' +
-      '<span class="or">or</span> ' +
-      '<a class="btn btn-default btn-sm" href="http://example.com" target="_blank">Contribute new contact details</a>' +
-      '</p>'
+      '<p>' + warningSentence + '</p><p>' + choicesSentence + '</p>'
     );
     $warning.insertAfter($chosenSelect);
     $warning.on('click', '.js-deselect', function(){

--- a/nuntium/static/sass/instance/_bootstrap.scss
+++ b/nuntium/static/sass/instance/_bootstrap.scss
@@ -26,7 +26,7 @@
 // @import "../bootstrap/badges";
 // @import "../bootstrap/jumbotron";
 // @import "../bootstrap/thumbnails";
-// @import "../bootstrap/alerts";
+@import "../bootstrap/alerts";
 // @import "../bootstrap/progress-bars";
 // @import "../bootstrap/media";
 @import "../bootstrap/list-group";

--- a/nuntium/static/sass/instance/_layout-write.scss
+++ b/nuntium/static/sass/instance/_layout-write.scss
@@ -126,6 +126,19 @@
   }
 }
 
+.uncontactable-alert {
+  margin-bottom: 0;
+  margin-top: 1em;
+
+  p:last-child {
+    margin-top: 0.75em;
+  }
+
+  .or {
+    margin: 0 0.5em;
+  }
+}
+
 .writing-draft-recipients {
   background-color: #f3f3f3;
   color: #999;

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -68,9 +68,25 @@ body, .site-footer {
   @include button-variant(#666, #eee, #e6e6e6);
 }
 
-.chosen-container .chosen-results li em {
-  font-weight: bold;
-  background: none;
+.chosen-container {
+  .chosen-results {
+    li em {
+      font-weight: bold;
+      background: none;
+    }
+
+    .uncontactable {
+      color: $color-red-900;
+      background-color: $color-red-50;
+
+      &:after {
+        content: "(no contact details)"; // This will be overridden by the HTML template
+        display: inline;
+        opacity: 0.7;
+        margin: 0 0.5em;
+      }
+    }
+  }
 }
 
 .thead__actions__heading,

--- a/nuntium/static/sass/instance/_style.scss
+++ b/nuntium/static/sass/instance/_style.scss
@@ -87,6 +87,14 @@ body, .site-footer {
       }
     }
   }
+
+  .chosen-choices {
+    .uncontactable {
+      color: $color-red-900;
+      background: $color-red-50;
+      border-color: mix($color-red-200, #ccc, 50%);
+    }
+  }
 }
 
 .thead__actions__heading,

--- a/nuntium/static/sass/instance/_variables.scss
+++ b/nuntium/static/sass/instance/_variables.scss
@@ -10,6 +10,9 @@ $color-bluegrey-200: #B0BEC5;
 $color-bluegrey-300: #90A4AE;
 $color-bluegrey-700: #455A64;
 
+$color-red-50: #FFEBEE;
+$color-red-900: #B71C1C;
+
 $font-size-base: 16px; // up from default 14px
 $brand-primary: $color-orange;
 $link-color: $color-blue;

--- a/nuntium/static/sass/instance/_variables.scss
+++ b/nuntium/static/sass/instance/_variables.scss
@@ -11,6 +11,8 @@ $color-bluegrey-300: #90A4AE;
 $color-bluegrey-700: #455A64;
 
 $color-red-50: #FFEBEE;
+$color-red-100: #FFCDD2;
+$color-red-200: #EF9A9A;
 $color-red-900: #B71C1C;
 
 $font-size-base: 16px; // up from default 14px
@@ -27,6 +29,10 @@ $pagination-hover-border:              $color-bluegrey-100;
 $pagination-active-color:              $color-bluegrey-700;
 $pagination-active-bg:                 #fff;
 $pagination-active-border:             $color-bluegrey-100;
+
+$state-danger-text:              $color-red-900;
+$state-danger-bg:                $color-red-50;
+$state-danger-border:            mix($color-red-200, #ccc, 50%);
 
 $chosen-sprite-path: '/static/img/chosen-sprite.png';
 $chosen-sprite-retina-path: '/static/img/chosen-sprite@2x.png';

--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -100,10 +100,15 @@ managepatterns = patterns('',
 
 )
 
+js_info_dict = {
+    'packages': ('nuntium',),
+}
+
 write_message_wizard = WriteMessageView.as_view(url_name='write_message_step')
 
 urlpatterns = i18n_patterns('',
     url(r'^$', WriteItInstanceDetailView.as_view(), name='instance_detail'),
+    url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog', js_info_dict),
     url(r'^write/sign/(?P<slug>[-\w]+)/$', ConfirmView.as_view(), name='confirm'),
     url(r'^write/sign/$', WriteSignView.as_view(), name='write_message_sign'),
     url(r'^write/(?P<step>.+)/$', write_message_wizard, name='write_message_step'),

--- a/nuntium/subdomain_urls.py
+++ b/nuntium/subdomain_urls.py
@@ -19,6 +19,7 @@ from nuntium.views import (
     WriteMessageView,
     WriteSignView,
     WriteItInstanceDetailView,
+    MissingContactsView,
     )
 from nuntium.user_section.views import (
     AcceptMessageView,
@@ -115,6 +116,7 @@ urlpatterns = i18n_patterns('',
     url(r'^write/$', write_message_wizard, name='write_message'),
     # url(r'^write/draft/$', TemplateView.as_view(template_name='write/draft.html'), name='write_draft'),
     # url(r'^write/preview/$', TemplateView.as_view(template_name='write/preview.html'), name='write_preview'),
+    url(r'^missing/$', MissingContactsView.as_view(), name='missing_contacts'),
     url(r'^threads/$', MessageThreadsView.as_view(), name='message_threads'),
     url(r'^thread/(?P<slug>[-\w]+)/$', MessageThreadView.as_view(), name='thread_read'),
     url(r'^per_person/(?P<pk>[-\d]+)/$', MessagesPerPersonView.as_view(), name='messages_per_person'),

--- a/nuntium/templates/write/missing_contacts.html
+++ b/nuntium/templates/write/missing_contacts.html
@@ -1,0 +1,32 @@
+{% extends "base_instance.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block promo %}
+{% endblock %}
+
+
+{% block content_inner %}
+
+  <h1>{% trans "Help to find missing contact details" context "Title of page appealing for help finding more contact details" %}</h1>
+
+  <p>
+    {% blocktrans trimmed %}
+      We don’t have an email address for any of the people
+      listed below. If you know or can find the email addresses
+      for any of them, please contact us using the following form:
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    [TODO: implement a form that sends an email to the instance owner;
+    that email address should not be revealed on the site.]
+  </p>
+
+  <ul>
+    {% for person in missing_people %}
+      <li>{{ person.name }}</li>
+    {% endfor %}
+  </ul>
+
+{% endblock content_inner %}

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -1,6 +1,7 @@
 {% extends "base_instance.html" %}
 {% load i18n %}
 {% load static %}
+{% load subdomainurls %}
 
 {% block extracss %}
     <style type="text/css">
@@ -11,6 +12,19 @@
 {% endblock extracss %}
 
 {% block extrascripts %}
+    {% comment %}
+        Unfortunately we can't use the 'as variable_name' form of
+        the subdomain 'url' tag, as you can with the standard Django url tag:
+          https://github.com/tkaemming/django-subdomains/issues/25
+        Ideally we would like to do that first, and then make
+        sure the escapejs filter is applied to the URL before being used
+        in a quoted Javascript string.  It shouldn't be possible to create
+        a XSS attack even without this, but it would be good to have the
+        extra assurance.
+    {% endcomment %}
+    <script>
+      var missingContactsURL = '{% url 'missing_contacts' subdomain=writeitinstance.slug %}';
+    </script>
     <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
     <script>

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -4,17 +4,14 @@
 
 {% block extrascripts %}
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
+    <script>
+    window.who = {
+        max_selected_options: {{ writeitinstance.config.maximum_recipients }},
+        no_results_text: '{% trans "No recipients match" %}'
+    }
+    </script>
+    <script src="{% static 'js/who.js' %}"></script>
 {% endblock extrascripts %}
-{% block extrajs %}
-    $(".chosen-person-select").chosen({
-      width: '100%',
-      max_selected_options: {{ writeitinstance.config.maximum_recipients }},
-      no_results_text: '{% trans "No recipients match" %}',
-      placeholder_text_multiple: ' ', // hide placeholder text
-      placeholder_text_single: ' ', // hide placeholder text
-      single_backstroke_delete: false
-    });
-{% endblock extrajs %}
 
 {% block content_inner %}
 
@@ -43,7 +40,7 @@
     </form>
 
   {% else %}
-  <h1>{% trans "Sorry" %}</h1> 
+  <h1>{% trans "Sorry" %}</h1>
   <p>{% trans "You can’t currently create new messages using this site." %}</p>
   {% endif %}
 

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -11,6 +11,7 @@
 {% endblock extracss %}
 
 {% block extrascripts %}
+    <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
     <script>
     window.who = {

--- a/nuntium/templates/write/who.html
+++ b/nuntium/templates/write/who.html
@@ -2,6 +2,14 @@
 {% load i18n %}
 {% load static %}
 
+{% block extracss %}
+    <style type="text/css">
+    .chosen-container .chosen-results .uncontactable:after {
+        content: '{% trans "(No contact details)" %}';
+    }
+    </style>
+{% endblock extracss %}
+
 {% block extrascripts %}
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
     <script>

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -121,7 +121,11 @@ class WriteMessageView(NamedUrlSessionWizardView):
 
     def get_form_kwargs(self, step):
         if step == 'who':
-            return {'persons_queryset': self.writeitinstance.persons_with_contacts.order_by('name')}
+            return {
+                'persons_queryset':
+                self.writeitinstance.persons \
+                    .prefetch_related('contact_set').order_by('name')
+            }
         elif step == 'draft':
             return {'allow_anonymous_messages': self.writeitinstance.config.allow_anonymous_messages}
         else:

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -344,6 +344,21 @@ class WriteSignView(TemplateView):
         return context
 
 
+class MissingContactsView(TemplateView):
+    template_name = 'write/missing_contacts.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(MissingContactsView, self).get_context_data(**kwargs)
+        wii = get_object_or_404(WriteItInstance, slug=self.request.subdomain)
+        context['writeitinstance'] = wii
+        # We exclude any person with an email address which is not
+        # bouncing. (It'd be good to find new email addresses to
+        # replace those that are bouncing.)
+        context['missing_people'] = wii.persons.exclude(
+            contact__is_bounced=False).order_by('name')
+        return context
+
+
 class AboutView(WriteItInstanceDetailView):
     template_name = 'about.html'
 

--- a/writeit/templates/subdomains/iran/write/missing_contacts.html
+++ b/writeit/templates/subdomains/iran/write/missing_contacts.html
@@ -1,0 +1,33 @@
+{% extends "base_instance.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block promo %}
+{% endblock %}
+
+
+{% block content_inner %}
+
+    <div class="full-width-wrapper write-wrapper">
+      <main class="centred write">
+
+        <h1>{% trans "Help to find missing contact details" context "Title of page appealing for help finding more contact details" %}</h1>
+
+        <p>
+          {% blocktrans trimmed with email='support@namehbeanha.com' %}
+            We don’t have an email address for any of the people
+            listed below. If you know or can find the email addresses
+            for any of them, please contact us at: {{email}}
+          {% endblocktrans %}
+        </p>
+
+        <ul>
+          {% for person in missing_people %}
+            <li>{{ person.name }}</li>
+          {% endfor %}
+        </ul>
+
+      </main>
+    </div>
+
+{% endblock content_inner %}

--- a/writeit/templates/subdomains/iran/write/who.html
+++ b/writeit/templates/subdomains/iran/write/who.html
@@ -12,6 +12,19 @@
 {% endblock extracss %}
 
 {% block extrascripts %}
+    {% comment %}
+        Unfortunately we can't use the 'as variable_name' form of
+        the subdomain 'url' tag, as you can with the standard Django url tag:
+          https://github.com/tkaemming/django-subdomains/issues/25
+        Ideally we would like to do that first, and then make
+        sure the escapejs filter is applied to the URL before being used
+        in a quoted Javascript string.  It shouldn't be possible to create
+        a XSS attack even without this, but it would be good to have the
+        extra assurance.
+    {% endcomment %}
+    <script>
+      var missingContactsURL = '{% url 'missing_contacts' subdomain=writeitinstance.slug %}';
+    </script>
     <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
     <script>
@@ -72,4 +85,3 @@
   {% endif %}
 
 {% endblock content_inner %}
-

--- a/writeit/templates/subdomains/iran/write/who.html
+++ b/writeit/templates/subdomains/iran/write/who.html
@@ -3,18 +3,17 @@
 {% load static %}
 
 {% block extrascripts %}
+    <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
     <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
+    <script>
+    window.who = {
+        max_selected_options: {{ writeitinstance.config.maximum_recipients }},
+        no_results_text: '{% trans "No recipients match" %}',
+        rtl: true
+    }
+    </script>
+    <script src="{% static 'js/who.js' %}"></script>
 {% endblock extrascripts %}
-{% block extrajs %}
-    $(".chosen-person-select").addClass('chosen-rtl').chosen({
-      width: '100%',
-      max_selected_options: {{ writeitinstance.config.maximum_recipients }},
-      no_results_text: '{% trans "No recipients match" %}',
-      placeholder_text_multiple: ' ', // hide placeholder text
-      placeholder_text_single: ' ', // hide placeholder text
-      single_backstroke_delete: false
-    });
-{% endblock extrajs %}
 
 {% block promo %}
 {% endblock %}

--- a/writeit/templates/subdomains/iran/write/who.html
+++ b/writeit/templates/subdomains/iran/write/who.html
@@ -1,6 +1,15 @@
 {% extends "base_instance.html" %}
 {% load i18n %}
 {% load static %}
+{% load subdomainurls %}
+
+{% block extracss %}
+    <style type="text/css">
+    .chosen-container .chosen-results .uncontactable:after {
+        content: '{% trans "(No contact details)" %}';
+    }
+    </style>
+{% endblock extracss %}
 
 {% block extrascripts %}
     <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>


### PR DESCRIPTION
After this pull request, people without email addresses are also offered as possible selections to write to. They are clearly marked as such, and users are given the option of either removing that recipient, or going to a page which lists all such people and appeals to the user to help in finding those email addresses. Here's @zarino's nice animation of the new selection process:

![dropdown](https://cloud.githubusercontent.com/assets/739624/18389340/70754308-769d-11e6-80d7-d08a912485e8.gif)

Things still to do:
- [ ] Add a "send email to the instance owner" contact form.
- [x] Look at an issue with the layout of the drop-down's text in RTL languages.

