### PR TITLE
Replace the broken references to chosen.css

### DIFF
--- a/nuntium/static/sass/manager.scss
+++ b/nuntium/static/sass/manager.scss
@@ -8,6 +8,9 @@
 // Use this file to specify which bits of Font-Awesome you want.
 @import "manager/font-awesome";
 
+// Styling for the jQuery Chosen plugin
+@import "bootstrap-chosen/_bootstrap-chosen";
+
 // Structural styles that are common across all themes.
 // You can access Bootstrap/Font-Awesome variables and mixins in here.
 @import "manager/layout";

--- a/nuntium/static/sass/manager/_variables.scss
+++ b/nuntium/static/sass/manager/_variables.scss
@@ -2,3 +2,6 @@
 $body-bg: #f3f1eb;
 $brand-primary: #4faded;
 $font-family-sans-serif: "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+$chosen-sprite-path: '/static/img/chosen-sprite.png';
+$chosen-sprite-retina-path: '/static/img/chosen-sprite@2x.png';

--- a/nuntium/templates/nuntium/profiles/templates.html
+++ b/nuntium/templates/nuntium/profiles/templates.html
@@ -5,7 +5,6 @@
 
 
 {% block extrascripts %}
-<link rel="stylesheet" href="{% static 'css/chosen.css' %}">
 <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
 {% endblock extrascripts %}
 {% block extrajs %}

--- a/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
+++ b/nuntium/templates/nuntium/profiles/writeitinstance_and_popit_relations.html
@@ -6,7 +6,6 @@
 
 
 {% block extrascripts %}
-<link rel="stylesheet" href="{% static 'css/chosen.css' %}">
 <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
 <script src="http://malsup.github.com/jquery.form.js"></script> 
 {% endblock extrascripts %}


### PR DESCRIPTION
Two template files referenced {% static 'css/chosen.css' %}, which was
removed in 6009225cbb23f46f.  That causes errors in production when
loading pages base on those templates.

That earlier commit switched to using bootstrap's styling for
the chosen.js-enhanced UI elements; this commit does the same to replace
the chosen.css references that are left.