### PR TITLE
Add an instance config option for stricter anonymity

### DIFF
--- a/instance/migrations/0003_add_name_and_email_match_config_option.py
+++ b/instance/migrations/0003_add_name_and_email_match_config_option.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0002_writeitinstanceconfig_allow_anonymous_messages'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='writeitinstanceconfig',
+            name='email_and_name_must_match',
+            field=models.BooleanField(default=False, help_text='When showing other messages by the same author, the public name must match as well as the hidden email'),
+            preserve_default=True,
+        ),
+    ]

--- a/instance/models.py
+++ b/instance/models.py
@@ -197,6 +197,11 @@ class WriteItInstanceConfig(models.Model):
     allow_anonymous_messages = models.BooleanField(
         help_text=_("Messages can have empty Author \
             names"), default=False)
+    email_and_name_must_match = models.BooleanField(
+        help_text=_(
+            "When showing other messages by the same author, the "
+            "public name must match as well as the hidden email"),
+            default=False)
 
     custom_from_domain = models.CharField(max_length=512, null=True, blank=True)
     email_host = models.CharField(max_length=512, null=True, blank=True)

--- a/nuntium/views.py
+++ b/nuntium/views.py
@@ -272,10 +272,17 @@ class MessagesFromPersonView(ListView):
             writeitinstance=self.writeitinstance,
             author_email=self.message.author_email
         )
-        if self.message.author_name == '':
-            qs = qs.filter(author_name='')
+        # There's a config option for stricter anonymity, which means
+        # that both author_name and author_email must match:
+        if self.writeitinstance.config.email_and_name_must_match:
+            qs = qs.filter(author_name=self.message.author_name)
         else:
-            qs = qs.exclude(author_name='')
+            # By default, don't mix up anonymous (author_name is blank)
+            # messages with non-anonymous (author_name is present) messages.
+            if self.message.author_name == '':
+                qs = qs.filter(author_name='')
+            else:
+                qs = qs.exclude(author_name='')
         return qs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
There is a view ('all-messages-from-the-same-author-as') which, given a
message slug, allows you to list any other messages with the same author
email address as the message with that slug. In situations where anonymity
is important, this is undesirable - someone might send a sensitive message
with a false name and an uncontroversial one with their real name, in
which case this view would reveal that they're sent by the same person.

This commit introduces a new instance config option
('email_and_name_must_match') which means that the
'all-messages-from-the-same-author-as' view will only show messages that
have the same author_email *and* author_name, to avoid this information
leak.

Fixes mysociety/alpaca#35
Fixes ciudadanointeligente/write-it#1194