### PR TITLE
Allow a custom "real name" in From: line from some site emails

### DIFF
--- a/instance/migrations/0004_add_email_real_name_to_config.py
+++ b/instance/migrations/0004_add_email_real_name_to_config.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0003_add_name_and_email_match_config_option'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='writeitinstanceconfig',
+            name='real_name_for_site_emails',
+            field=models.TextField(default=b'', help_text='The name that should appear in the From: line of emails sent from this site', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/instance/models.py
+++ b/instance/models.py
@@ -186,6 +186,12 @@ class WriteItInstanceConfig(models.Model):
     allow_messages_using_form = models.BooleanField(
         help_text=_("Allow the creation of new messages \
         using the web"), default=True)
+    real_name_for_site_emails = models.TextField(
+        help_text=_(
+            "The name that should appear in the From: line "
+            "of emails sent from this site"),
+        default='',
+        blank=True)
     rate_limiter = models.IntegerField(default=0)
     notify_owner_when_new_answer = models.BooleanField(
         help_text=_("The owner of this instance \

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -348,6 +348,11 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
                 from_domain,
                 )
 
+        real_name = writeitinstance.config.real_name_for_site_emails
+        if real_name:
+            from_email = u'{real_name} <{email}>'.format(
+                real_name=real_name, email=from_email)
+
         subscribers = answer.message.subscribers.all()
 
         if writeitinstance.config.notify_owner_when_new_answer:
@@ -642,6 +647,12 @@ def send_confirmation_email(sender, instance, created, **kwargs):
                 confirmation.message.writeitinstance.slug,
                 from_domain,
                 )
+        real_name = \
+            confirmation.message.writeitinstance.config.real_name_for_site_emails
+        if real_name:
+            from_email = u'{real_name} <{email}>'.format(
+                real_name=real_name, email=from_email)
+
         connection = confirmation.message.writeitinstance.config.get_mail_connection()
 
         msg = EmailMultiAlternatives(

--- a/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
@@ -18,6 +18,7 @@
 
 
     <form role="form" action="" method="post">
+      {{ form.non_field_errors }}
       <div class="settings-group">
       <h3>{% trans 'Site name for emails' %}</h3>
         <p class="help-block">{% blocktrans %}
@@ -27,6 +28,7 @@
           that real name here.
     {% endblocktrans %}</p>
         <div class="form-group">
+          {{form.real_name_for_site_emails.errors}}
           {{form.real_name_for_site_emails.label_tag}}
           {{form.real_name_for_site_emails}}
         </div>
@@ -38,6 +40,7 @@
     responses to messages to your email address.
     {% endblocktrans %}</p>
         <div class="form-group">
+          {{form.notify_owner_when_new_answer.errors}}
           {{form.notify_owner_when_new_answer.label_tag}}
           {{form.notify_owner_when_new_answer}}
         </div>

--- a/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
+++ b/nuntium/templates/nuntium/writeitinstance_answernotification_form.html
@@ -19,6 +19,19 @@
 
     <form role="form" action="" method="post">
       <div class="settings-group">
+      <h3>{% trans 'Site name for emails' %}</h3>
+        <p class="help-block">{% blocktrans %}
+          If you want there to be a real name in addition to
+          email address in the "From:" line of confirmation
+          emails, etc. that the site sends, then you can set
+          that real name here.
+    {% endblocktrans %}</p>
+        <div class="form-group">
+          {{form.real_name_for_site_emails.label_tag}}
+          {{form.real_name_for_site_emails}}
+        </div>
+      </div>
+      <div class="settings-group">
       <h3>{% trans 'Answer notification' %}</h3>
         <p class="help-block">{% blocktrans %}
     If you turn on “Answer Notification”, you will receive copies of all

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from global_test_case import GlobalTestCase as TestCase
 from instance.models import WriteItInstance
 from ..models import Subscriber, Message, \
@@ -169,6 +171,24 @@ class NewAnswerNotificationToSubscribers(TestCase):
             mail.outbox[0].from_email,
             self.instance.slug + "@" + settings.DEFAULT_FROM_DOMAIN,
             )
+
+    def test_when_an_answer_is_created_then_a_mail_is_sent_to_the_subscribers_with_real_name(self):
+        config = self.instance.config
+        config.real_name_for_site_emails = u'☃ The Snowman ☃'
+        config.save()
+        self.create_a_new_answer()
+
+        self.assertEquals(len(mail.outbox), 1)
+        email_to_check = mail.outbox[0]
+        expected_email_address = self.message.writeitinstance.slug + "@" + settings.DEFAULT_FROM_DOMAIN
+        expected_real_name = u'☃ The Snowman ☃'
+        expected_from = u'{real_name} <{email}>'.format(
+            real_name=expected_real_name,
+            email=expected_email_address)
+        self.assertEquals(email_to_check.from_email, expected_from)
+        self.assertIn(
+            'From: =?utf-8?b?4piDIFRoZSBTbm93bWFuIOKYgw==?=',
+            str(email_to_check.message()))
 
     def test_new_answer_notification_email_uses_sensible_language(self):
         self.instance.config.default_language = 'fa'

--- a/nuntium/user_section/forms.py
+++ b/nuntium/user_section/forms.py
@@ -77,9 +77,10 @@ class WriteItInstanceBasicForm(ModelForm):
 class WriteItInstanceAnswerNotificationForm(ModelForm):
     class Meta:
         model = WriteItInstanceConfig
-        fields = ['notify_owner_when_new_answer']
+        fields = ['notify_owner_when_new_answer', 'real_name_for_site_emails']
         widgets = {
             'notify_owner_when_new_answer': CheckboxInput(attrs={'class': 'form-control'}),
+            'real_name_for_site_emails': TextInput(attrs={'class': 'form-control'}),
         }
 
 

--- a/nuntium/user_section/tests/user_section_views_tests.py
+++ b/nuntium/user_section/tests/user_section_views_tests.py
@@ -162,7 +162,10 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
 
     def test_turning_answer_notification_on(self):
         url = reverse('writeitinstance_answernotification_update', subdomain=self.writeitinstance.slug)
-        modified_data = {'notify_owner_when_new_answer': 'on'}
+        modified_data = {
+            'notify_owner_when_new_answer': 'on',
+            'real_name_for_site_emails': '',
+        }
         self.client.login(username=self.owner.username, password='admin')
         self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)
@@ -170,7 +173,9 @@ class WriteitInstanceAdvancedUpdateTestCase(UserSectionTestCase):
 
     def test_turning_answer_notification_off(self):
         url = reverse('writeitinstance_answernotification_update', subdomain=self.writeitinstance.slug)
-        modified_data = {}
+        modified_data = {
+            'real_name_for_site_emails': '',
+        }
         self.client.login(username=self.owner.username, password='admin')
         self.client.post(url, data=modified_data, follow=True)
         writeitinstance = WriteItInstance.objects.get(id=self.writeitinstance.id)


### PR DESCRIPTION
We had complaints from partner that the confirmation emails from the
site appeared to be from 'belgium-reps', say, in your mail client if
the email was From: belgium-reps@example.com

To address this problem, this commit adds an instance configuration
setting for the real name that should be used in the From: line of
confirmation emails and answer notification emails.  (This can be
any unicode string, and it will be encoded sensibly by Django's
smtp backend.)