### PR TITLE
An 'updated' DateTimeField should use auto_now, not auto_now_add

### DIFF
--- a/instance/migrations/0013_fix_record_auto_updated_field.py
+++ b/instance/migrations/0013_fix_record_auto_updated_field.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0012_writeitinstanceconfig_include_area_names'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='writeitinstancepopitinstancerecord',
+            name='updated',
+            field=models.DateTimeField(auto_now=True),
+            preserve_default=True,
+        ),
+    ]

--- a/instance/models.py
+++ b/instance/models.py
@@ -311,11 +311,12 @@ class WriteItInstance(models.Model):
         pass
 
     def _load_persons_from_popolo_json(self, popolo_source):
-        success_relating_people, error = self.relate_with_persons_from_popolo_json(popolo_source)
         record, created = WriteitInstancePopitInstanceRecord.objects.get_or_create(
             writeitinstance=self,
             popolo_source=popolo_source
             )
+        record.set_status('inprogress')
+        success_relating_people, error = self.relate_with_persons_from_popolo_json(popolo_source)
         if success_relating_people:
             record.set_status('success')
         else:
@@ -335,7 +336,6 @@ class WriteItInstance(models.Model):
         if not created:
             record.updated = datetime.datetime.today()
             record.save()
-        record.set_status('inprogress')
         from nuntium.tasks import pull_from_popolo_json
         return pull_from_popolo_json.delay(self, popolo_source)
 

--- a/instance/models.py
+++ b/instance/models.py
@@ -312,7 +312,7 @@ class WriteItInstance(models.Model):
 
     def _load_persons_from_popolo_json(self, popolo_source):
         success_relating_people, error = self.relate_with_persons_from_popolo_json(popolo_source)
-        record = WriteitInstancePopitInstanceRecord.objects.get(
+        record, created = WriteitInstancePopitInstanceRecord.objects.get_or_create(
             writeitinstance=self,
             popolo_source=popolo_source
             )
@@ -410,7 +410,7 @@ class WriteitInstancePopitInstanceRecord(models.Model):
         default="nothing",
         )
     status_explanation = models.TextField(default='')
-    updated = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True, editable=False)
 
     def __unicode__(self):

--- a/instance/models.py
+++ b/instance/models.py
@@ -329,13 +329,10 @@ class WriteItInstance(models.Model):
     def load_persons_from_popolo_json(self, popolo_json_url):
         '''This is an async wrapper for getting people from the api'''
         popolo_source, created = PopoloSource.objects.get_or_create(url=popolo_json_url)
-        record, created = WriteitInstancePopitInstanceRecord.objects.get_or_create(
+        WriteitInstancePopitInstanceRecord.objects.get_or_create(
             writeitinstance=self,
             popolo_source=popolo_source
             )
-        if not created:
-            record.updated = datetime.datetime.today()
-            record.save()
         from nuntium.tasks import pull_from_popolo_json
         return pull_from_popolo_json.delay(self, popolo_source)
 

--- a/nuntium/tests/popit_writeit_relation_tests.py
+++ b/nuntium/tests/popit_writeit_relation_tests.py
@@ -162,6 +162,29 @@ class PopitWriteitRelationRecord(TestCase):
         self.assertNotEqual(record.created, record.updated)
 
     @popit_load_data()
+    def test_record_updated_should_be_updated_using_inner_function(self):
+        '''It should be able to update all data twice'''
+        # loading data into the popit-api
+        writeitinstance = WriteItInstance.objects.create(
+            name='instance 1',
+            slug='instance-1',
+            owner=self.owner,
+            )
+
+        popolo_source, _ = PopoloSource.objects.get_or_create(url=settings.TEST_POPIT_API_URL)
+        writeitinstance._load_persons_from_popolo_json(popolo_source)
+        record = WriteitInstancePopitInstanceRecord.objects.get(
+            writeitinstance=writeitinstance,
+            popolo_source=popolo_source,
+            )
+        updated_after_first = record.updated
+        writeitinstance._load_persons_from_popolo_json(popolo_source)
+        record = WriteitInstancePopitInstanceRecord.objects.get(pk=record.id)
+        updated_after_second = record.updated
+
+        self.assertNotEqual(updated_after_first, updated_after_second)
+
+    @popit_load_data()
     def test_it_should_update_the_date_every_time_it_is_updated(self):
         '''As described in http://github.com/ciudadanointeligente/write-it/issues/412 the updated date is not updated'''
         # loading data into the popit-api


### PR DESCRIPTION
auto_now_add=True only sets the date when the object is first created,
which is only suitable for the 'created' field. auto_now=True is the
correct option for 'updated'.

This pull request also contains a commit to make sure that the
'inprogress' status is set however syncing is initiated, and one to remove
some unnecessary code.