### PR TITLE
raise and handle exception on temporary mail failure

### DIFF
--- a/mailit/bin/handleemail.py
+++ b/mailit/bin/handleemail.py
@@ -12,7 +12,7 @@ from flufl.bounce import all_failures, scan_message
 from mailit.models import RawIncomingEmail
 from nuntium.models import Answer
 from mailit.bin.froide_email_utils import FroideEmailParser
-from mailit.exceptions import CouldNotFindIdentifier
+from mailit.exceptions import CouldNotFindIdentifier, TemporaryFailure
 
 logging.basicConfig(filename='mailing_logger.txt', level=logging.INFO)
 
@@ -152,9 +152,11 @@ class EmailHandler(FroideEmailParser):
         msg = email.message_from_string(msgtxt)
         temporary, permanent = all_failures(msg)
 
-        if temporary or permanent:
+        if permanent:
             answer.is_bounced = True
             answer.email_from = scan_message(msg).pop()
+        elif temporary:
+            raise TemporaryFailure
         else:
             answer.email_from = msg["From"]
 

--- a/mailit/exceptions.py
+++ b/mailit/exceptions.py
@@ -1,2 +1,6 @@
 class CouldNotFindIdentifier(Exception):
     pass
+
+
+class TemporaryFailure(Exception):
+    pass

--- a/mailit/management/commands/handleemail.py
+++ b/mailit/management/commands/handleemail.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.mail.message import EmailMultiAlternatives
 import traceback
 from django.core.files import File
-from mailit.exceptions import CouldNotFindIdentifier
+from mailit.exceptions import CouldNotFindIdentifier, TemporaryFailure
 
 logging.basicConfig(filename='mailing_logger.txt', level=logging.INFO)
 
@@ -66,6 +66,8 @@ class Command(BaseCommand):
             answer = handler.handle(lines)
             answer.send_back()
         except CouldNotFindIdentifier:
+            pass
+        except TemporaryFailure:
             pass
         except:
             tb = traceback.format_exc()

--- a/mailit/tests/fixture/temporary.txt
+++ b/mailit/tests/fixture/temporary.txt
@@ -1,0 +1,28 @@
+From MAILER-DAEMON Sun Dec 25 22:45:51 2016
+Received: from Debian-exim by localhost with local (Exim 4.82)
+	id 1cLHY7-0006zM-CG
+	for test+91701f6cc88011e6a5f622000ba09833@localhost; Sun, 25 Dec 2016 22:45:51 +0000
+Auto-Submitted: auto-replied
+From: Mail Delivery System <Mailer-Daemon@localhost>
+To: test+91701f6cc88011e6a5f622000ba09833@localhost
+Subject: Warning: message 1cK9kW-0006jE-Hb delayed 72 hours
+Message-Id: <E1cLHY7-0006zM-CG@localhost>
+Date: Sun, 25 Dec 2016 22:45:51 +0000
+
+This message was created automatically by mail delivery software.
+A message that you sent has not yet been delivered to one or more of its
+recipients after more than 72 hours on the queue on ip-10-109-190-211.ec2.internal.
+
+The message identifier is:     1cK9kW-0006jE-Hb
+The subject of the message is: This is a test message
+The date of the message is:    Thu, 22 Dec 2016 20:14:00 -0000
+
+The address to which the message has not yet been delivered is:
+
+  foo@example.com
+
+No action is required on your part. Delivery attempts will continue for
+some time, and this warning may be repeated at intervals if the message
+remains undelivered. Eventually the mail delivery software will give up,
+and when that happens, the message will be returned to you.
+

--- a/mailit/tests/handle_mails_management_command_test.py
+++ b/mailit/tests/handle_mails_management_command_test.py
@@ -7,6 +7,8 @@ from mock import patch
 from django.core import mail
 from django.test.utils import override_settings
 from mailit.models import RawIncomingEmail
+from mailit.bin.handleemail import EmailHandler
+from mailit.exceptions import TemporaryFailure
 
 
 class ManagementCommandAnswer(TestCase):
@@ -110,6 +112,10 @@ def readlines4_mock():
     return read_lines('mailit/tests/fixture/mail_from_tony.txt')
 
 
+def temporary_fail_mock():
+    return read_lines('mailit/tests/fixture/temporary.txt')
+
+
 class HandleIncomingEmailCommand(TestCase):
     def setUp(self):
         super(HandleIncomingEmailCommand, self).setUp()
@@ -179,3 +185,8 @@ class HandleIncomingEmailCommand(TestCase):
             self.assertNotIn('Tony', the_answer.content)
             self.assertNotIn('<eduskunta-', the_answer.content)
             self.assertNotIn('>', the_answer.content)
+
+    def test_temporary_failure_raises_temp_fail_error(self):
+        handler = EmailHandler(answer_class=AnswerForManageCommand)
+        with self.assertRaises(TemporaryFailure):
+            handler.handle(temporary_fail_mock())


### PR DESCRIPTION
If we get a temporary failure message then ignore it as we only need to
do something if the failure is permanent.