### PR TITLE
Install gettext in vagrant box

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -29,7 +29,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python-dev python-pip python-virtualenv \
   rabbitmq-server \
   openjdk-7-jre elasticsearch \
-  mongodb-org nodejs
+  mongodb-org nodejs gettext
 
 # Set virtualenv directory and create it if needed.
 virtualenv_dir="/home/vagrant/writeit-virtualenv"


### PR DESCRIPTION
I needed to add this package to get `vagrant up` working correctly. I'm
not entirely sure why this wasn't needed before, perhaps it was in a
previous version of the base box but was subsequently removed?