### PR TITLE
Fix sending of email bounces when handling incoming email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ python:
   - "2.7"
 # command to install dependencies
 services:
-  - elasticsearch
   - rabbitmq
 install:
+  # Install and run Elasticsearch:
+  - wget ${ES_DOWNLOAD_URL}
+  - tar xzf elasticsearch-${ES_VERSION}.tar.gz
+  - elasticsearch-${ES_VERSION}/bin/elasticsearch &
   - pip install -r requirements.txt
   - pip install psycopg2
   - pip install -r requirements_testing.txt
@@ -17,11 +20,11 @@ install:
 before_script:
   - psql -c 'create database writeit;' -U postgres
 script:
+  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - coverage run --source=nuntium,contactos,mailit,instance manage.py test nuntium contactos mailit instance
   - coverage report -m
 after_script:
   - coveralls --verbose
 env:
-  - DB=postgres
-  - DB=sqlite3
-
+  - DB=postgres ES_VERSION=1.4.5 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - DB=sqlite3 ES_VERSION=1.4.5 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 before_script:
   - psql -c 'create database writeit;' -U postgres
 script:
-  - coverage run --source=nuntium,contactos,mailit manage.py test nuntium contactos mailit
+  - coverage run --source=nuntium,contactos,mailit,instance manage.py test nuntium contactos mailit instance
   - coverage report -m
 after_script:
   - coveralls --verbose

--- a/writeit/template_loaders.py
+++ b/writeit/template_loaders.py
@@ -19,7 +19,10 @@ class SubdomainFilesystemLoader(Loader):
         Any paths that don't lie inside one of the template dirs are excluded
         from the result set, for security reasons.
         """
-        subdomain = SubdomainInThreadLocalStorageMiddleware.tls.subdomain
+        try:
+            subdomain = SubdomainInThreadLocalStorageMiddleware.tls.subdomain
+        except AttributeError:
+            return
         if not subdomain:
             return
         if not template_dirs:


### PR DESCRIPTION
Since the merging of https://github.com/ciudadanointeligente/write-it/pull/1216 then sending of email bounces when handing incoming email has been failing because the `subdomain` attribute was missing from thread-local storage. This pull request fixes that as described in the commit messages.